### PR TITLE
add more context to nativeModuleNotFound error

### DIFF
--- a/fiftyone.devicedetection.onpremise/deviceDetectionOnPremise.js
+++ b/fiftyone.devicedetection.onpremise/deviceDetectionOnPremise.js
@@ -316,7 +316,8 @@ class DeviceDetectionOnPremise extends Engine {
           throw util.format(
             errorMessages.nativeModuleNotFound,
             moduleName,
-            availableModules);
+            availableModules,
+            err);
         }
       }
       dataFileType = 'HashV41';

--- a/fiftyone.devicedetection.shared/errorMessages.js
+++ b/fiftyone.devicedetection.shared/errorMessages.js
@@ -32,12 +32,12 @@ module.exports = {
   moduleDirNotFound: 'There is no directory at \'%s\'. This is ' +
     'expected to contain the native modules for the hash engine.' +
     ' For example, %s',
-  nativeModuleNotFound: 'Native module \'%s\' not found. This is probably ' +
+  nativeModuleNotFound: 'Failed to load native module \'%s\'. This is probably ' +
     'because a module for this platform and Node version has not been ' +
     'included with this distribution. Try changing to a platform and Node ' +
     'version from the list of available modules: %s. If the platform/version ' +
     'you want is not listed then please contact us directly for assistance: ' +
-    'https://51degrees.com/contact-us',
+    'https://51degrees.com/contact-us. Original error: \'%s\'',
   invalidFileExtension: 'dataFilePath must point to a file with a ".hash" ' +
     'extension',
   licenseKeyRequired: 'license key is required. A key can be obtained from ' +


### PR DESCRIPTION
sometimes the native module is not loaded due to missing native libs in the environment it's run on. So it's helpful to get a detailed error 