### PR TITLE
Deprecate Perfomance/Predictive graph flags

### DIFF
--- a/fiftyone.devicedetection.onpremise/deviceDetectionOnPremise.js
+++ b/fiftyone.devicedetection.onpremise/deviceDetectionOnPremise.js
@@ -227,9 +227,9 @@ class DeviceDetectionOnPremise extends Engine {
    * temporary data copy if 'createTempDataCopy' is set to true.
    * @param {boolean} options.updateOnStart whether to download / update
    * the datafile on initialisation
-   * @param {boolean} options.usePredictiveGraph If true, the engine will
+   * @param {boolean} options.usePredictiveGraph [deprecated] If true, the engine will
    * use predictive optimized graph in detections.
-   * @param {boolean} options.usePerformanceGraph If true, the engine will
+   * @param {boolean} options.usePerformanceGraph [deprecated] If true, the engine will
    * use performance optimized graph in detections.
    */
   constructor (
@@ -256,13 +256,18 @@ class DeviceDetectionOnPremise extends Engine {
       updateTimeMaximumRandomisation,
       createTempDataCopy,
       tempDataDir = os.tmpdir(),
-      updateOnStart = false,
-      usePredictiveGraph = true,
-      usePerformanceGraph = false
+      updateOnStart = false
     }) {
     let swigWrapper;
     let swigWrapperType;
     let dataFileType;
+
+    const deprecatedOptions = ['usePredictiveGraph', 'usePerformanceGraph'];
+    for (const option of deprecatedOptions) {
+      if (arguments[0].hasOwnProperty(option)) {
+        console.warn(`{${option}} option is deprecated and has no effect on the configuration`);
+      }
+    }
 
     if (typeof cache !== 'undefined') {
       throw errorMessages.cacheNotSupport;
@@ -406,10 +411,6 @@ class DeviceDetectionOnPremise extends Engine {
     }
 
     config.setConcurrency(concurrency);
-
-    config.setUsePredictiveGraph(usePredictiveGraph);
-
-    config.setUsePerformanceGraph(usePerformanceGraph);
 
     // This should always be set to 'false' for on-premise
     config.setUseUpperPrefixHeaders(false);

--- a/fiftyone.devicedetection.onpremise/deviceDetectionOnPremisePipelineBuilder.js
+++ b/fiftyone.devicedetection.onpremise/deviceDetectionOnPremisePipelineBuilder.js
@@ -94,9 +94,9 @@ class DeviceDetectionOnPremisePipelineBuilder extends PipelineBuilder {
    * automatic data updates to occur.
    * @param {string} options.tempDataDir The directory to use for the
    * temporary data copy if 'createTempDataCopy' is set to true.
-   * @param {boolean} options.usePredictiveGraph True, the engine will use
+   * @param {boolean} options.usePredictiveGraph [deprecated] True, the engine will use
    * the predictive optimized graph to in detections.
-   * @param {boolean} options.usePerformanceGraph True, the engine will use
+   * @param {boolean} options.usePerformanceGraph [deprecated] True, the engine will use
    * the performance optimized graph to in detections.
    *
    * @param options.dataFileUpdateService
@@ -125,11 +125,16 @@ class DeviceDetectionOnPremisePipelineBuilder extends PipelineBuilder {
       difference,
       allowUnmatched = false,
       createTempDataCopy,
-      tempDataDir,
-      usePredictiveGraph = true,
-      usePerformanceGraph = false
+      tempDataDir
     }) {
     super(...arguments);
+
+    const deprecatedOptions = ['usePredictiveGraph', 'usePerformanceGraph'];
+    for (const option of deprecatedOptions) {
+      if (arguments[0].hasOwnProperty(option)) {
+        console.warn(`{${option}} option is deprecated and has no effect on the configuration`);
+      }
+    }
 
     // Check if share usage enabled and add it to the pipeline if so
 
@@ -165,9 +170,7 @@ class DeviceDetectionOnPremisePipelineBuilder extends PipelineBuilder {
         allowUnmatched,
         updateOnStart,
         createTempDataCopy,
-        tempDataDir,
-        usePredictiveGraph,
-        usePerformanceGraph
+        tempDataDir
       }));
   }
 }

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/matchmetrics-console/matchMetrics.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/matchmetrics-console/matchMetrics.js
@@ -208,12 +208,6 @@ const run = async function (dataFile, output, evidenceList) {
     // Uncomment 'browsername' to include Browser component as well. This can be seen by looking
     // for the browser profile ID in the device ID value.
     restrictedProperties: ['ismobile', 'hardwarename', 'userAgents', 'deviceID', 'difference', 'method', 'matchedNodes', 'drift', 'iterations'], /* , 'browsername' */
-    // Only use the predictive graph to better handle variances between the training data and the
-    // target User-Agent string. For a more detailed description of the differences between
-    // performance and predictive, see
-    // https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Performance
-    usePredictiveGraph: true,
-    usePerformanceGraph: false,
     // We want to show the matching evidence characters as part of this example, so we have to set
     // this flag to true.
     updateMatchedUserAgent: true

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/performance-console/performance.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/performance-console/performance.js
@@ -172,8 +172,6 @@ const pipeline = new DeviceDetectionOnPremisePipelineBuilder({
   restrictedProperties: ['ismobile'],
   autoUpdate: false,
   shareUsage: false,
-  usePredictiveGraph: false,
-  usePerformanceGraph: true,
   addJavaScriptBuilder: false
 }).build();
 

--- a/fiftyone.devicedetection.onpremise/types/deviceDetectionOnPremise.d.ts
+++ b/fiftyone.devicedetection.onpremise/types/deviceDetectionOnPremise.d.ts
@@ -62,12 +62,12 @@ declare class DeviceDetectionOnPremise extends DeviceDetectionOnPremise_base {
      * automatic data updates to occur.
      * @param {boolean} options.updateOnStart whether to download / update
      * the datafile on initialisation
-     * @param {boolean} options.usePredictiveGraph If true, the engine will
+     * @param {boolean} options.usePredictiveGraph [deprecated] If true, the engine will
      * use predictive optimized graph in detections.
-     * @param {boolean} options.usePerformanceGraph If true, the engine will
+     * @param {boolean} options.usePerformanceGraph [deprecated] If true, the engine will
      * use performance optimized graph in detections.
      */
-    constructor({ dataFilePath, autoUpdate, cache, dataFileUpdateBaseUrl, restrictedProperties, licenceKeys, download, performanceProfile, reuseTempFile, updateMatchedUserAgent, maxMatchedUserAgentLength, drift, difference, concurrency, allowUnmatched, fileSystemWatcher, pollingInterval, updateTimeMaximumRandomisation, createTempDataCopy, updateOnStart, usePredictiveGraph, usePerformanceGraph }: {
+    constructor({ dataFilePath, autoUpdate, cache, dataFileUpdateBaseUrl, restrictedProperties, licenceKeys, download, performanceProfile, reuseTempFile, updateMatchedUserAgent, maxMatchedUserAgentLength, drift, difference, concurrency, allowUnmatched, fileSystemWatcher, pollingInterval, updateTimeMaximumRandomisation, createTempDataCopy, updateOnStart }: {
         dataFilePath: string;
         autoUpdate: boolean;
         pollingInterval: number;
@@ -88,8 +88,6 @@ declare class DeviceDetectionOnPremise extends DeviceDetectionOnPremise_base {
         allowUnmatched: boolean;
         createTempDataCopy: boolean;
         updateOnStart: boolean;
-        usePredictiveGraph: boolean;
-        usePerformanceGraph: boolean;
     }, ...args: any[]);
     initEngine: () => Promise<any>;
 }

--- a/fiftyone.devicedetection.onpremise/types/deviceDetectionOnPremisePipelineBuilder.d.ts
+++ b/fiftyone.devicedetection.onpremise/types/deviceDetectionOnPremisePipelineBuilder.d.ts
@@ -54,13 +54,13 @@ declare class DeviceDetectionOnPremisePipelineBuilder extends DeviceDetectionOnP
      * This means that properties will always have values
      * (i.e. no need to check .HasValue) but some may be inaccurate.
      * By default, this is false.
-     * @param {boolean} options.usePredictiveGraph True, the engine will use
+     * @param {boolean} options.usePredictiveGraph [deprecated] True, the engine will use
      * the predictive optimized graph to in detections.
-     * @param {boolean} options.usePerformanceGraph True, the engine will use
+     * @param {boolean} options.usePerformanceGraph [deprecated] True, the engine will use
      * the performance optimized graph to in detections.
      *
      */
-    constructor({ licenceKeys, dataFile, autoUpdate, pollingInterval, updateTimeMaximumRandomisation, shareUsage, fileSystemWatcher, updateOnStart, cacheSize, restrictedProperties, performanceProfile, updateMatchedUserAgent, maxMatchedUserAgentLength, drift, difference, allowUnmatched, usePredictiveGraph, usePerformanceGraph }: {
+    constructor({ licenceKeys, dataFile, autoUpdate, pollingInterval, updateTimeMaximumRandomisation, shareUsage, fileSystemWatcher, updateOnStart, cacheSize, restrictedProperties, performanceProfile, updateMatchedUserAgent, maxMatchedUserAgentLength, drift, difference, allowUnmatched }: {
         licenceKeys: string;
         dataFile: string;
         autoUpdate: boolean;
@@ -77,7 +77,5 @@ declare class DeviceDetectionOnPremisePipelineBuilder extends DeviceDetectionOnP
         drift: number;
         difference: number;
         allowUnmatched: string;
-        usePredictiveGraph: boolean;
-        usePerformanceGraph: boolean;
     }, ...args: any[]);
 }

--- a/fiftyone.devicedetection/deviceDetectionPipelineBuilder.js
+++ b/fiftyone.devicedetection/deviceDetectionPipelineBuilder.js
@@ -94,10 +94,10 @@ class DeviceDetectionPipelineBuilder extends PipelineBuilder {
    * This means that properties will always have values
    * (i.e. no need to check .HasValue) but some may be inaccurate.
    * By default, this is false.
-   * @param {boolean} options.usePredictiveGraph This setting on affects
+   * @param {boolean} options.usePredictiveGraph [deprecated] This setting on affects
    * on-premise engines, not cloud.
    * True, the engine will use the predictive optimized graph to in detections.
-   * @param {boolean} options.usePerformanceGraph This setting on affects
+   * @param {boolean} options.usePerformanceGraph [deprecated] This setting on affects
    * on-premise engines, not cloud.
    * True, the engine will use the performance optimized graph to in detections.
    * @param {string} options.cloudEndPoint This setting only affects
@@ -127,13 +127,18 @@ class DeviceDetectionPipelineBuilder extends PipelineBuilder {
       drift,
       difference,
       allowUnmatched = false,
-      usePredictiveGraph = true,
-      usePerformanceGraph = false,
       updateOnStart = false,
       cloudEndPoint = null,
       cloudRequestOrigin = null
     }) {
     super(...arguments);
+
+    const deprecatedOptions = ['usePredictiveGraph', 'usePerformanceGraph'];
+    for (const option of deprecatedOptions) {
+      if (arguments[0].hasOwnProperty(option)) {
+        console.warn(`{${option}} option is deprecated and has no effect on the configuration`);
+      }
+    }
 
     // Check if share usage enabled and add it to the pipeline if so
 
@@ -168,9 +173,7 @@ class DeviceDetectionPipelineBuilder extends PipelineBuilder {
           drift,
           difference,
           allowUnmatched,
-          updateOnStart,
-          usePredictiveGraph,
-          usePerformanceGraph
+          updateOnStart
         }));
     } else {
       // First we need the cloudRequestEngine


### PR DESCRIPTION
Fixes https://github.com/51Degrees/device-detection-node/issues/159

 > 1. `DeviceDetectionOnPremise` (and `DeviceDetectionOnPremisePipelineBuilder`) contains `usePerformanceGraph` and `usePredictiveGraph` flags - they have to be marked as deprecated in the code comments and we should output a warning whenever either of them is used telling: "{option_name} option is deprecated and has no effect on the configuration". If they can be removed from the parameter list (i.e. parameters are named and not positional - it would be ideal).
 > 2. The internal code has to be updated so they indeed have no effect on the engine configuration.
> 3. We must remove them from the examples (at least `performance-console` I believe uses them) and verify that the examples actually work.