### PR TITLE
Rename incorrect options key

### DIFF
--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/dataFileSystemWatcher.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/dataFileSystemWatcher.js
@@ -90,7 +90,7 @@ if (myLicenseKey === '!!YOUR_LICENSE_KEY!!') {
     autoUpdate: true,
     // Watch the data file on disk and refresh the engine
     // as soon as that file is updated.
-    dataFileSystemWatcher: true
+    fileSystemWatcher: true
   }).build();
 
   // To monitor the pipeline we can put in listeners for various log events.

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/updatedatafile-console/updatedatafile.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/updatedatafile-console/updatedatafile.js
@@ -324,7 +324,7 @@ const run = async function (dataFilePath, licenseKey, interactive, output) {
     updateOnStart: true,
     // Watch the data file on disk and refresh the engine
     // as soon as that file is updated.
-    dataFileSystemWatcher: true,
+    fileSystemWatcher: true,
     // for the purposes of this example we are setting the time
     // between checks to see if the file has changed to 1 second
     // by default this is 30 mins


### PR DESCRIPTION
Correct the options key for the `DeviceDetectionOnPremisePipelineBuilder` object in the examples.
The previous key name was incorrect, resulting in no effect when used. This update changes it to the correct key name.
