### PR TITLE
fix: ignore doxygen output directory 4.5 instead of stale 4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,6 @@ public
 fiftyone.devicedetection/test_results.xml
 
 #docs
-4.1/*
+4.5/*
 package-lock.json
 fiftyone.devicedetection.onpremise/build/


### PR DESCRIPTION
## Summary

Changes the `#docs` entry in `.gitignore` from `4.1/*` to `4.5/*` so it matches `HTML_OUTPUT = 4.5` in `docs/Doxyfile`.

The `4.1/*` entry was a leftover from an earlier documentation version. With the current Doxyfile the generated documentation lands in a repo-root `4.5/` directory, which was not ignored, so a local docs build left ~150 generated files untracked in `git status` and visible to repo-wide tooling such as eslint.

Fixes #406

## Testing

Verified against this repository's `docs/Doxyfile` (`PROJECT_NUMBER = 4.5`, `HTML_OUTPUT = 4.5`). The equivalent correction was applied and exercised in ip-intelligence-node, where a docs build into `4.5/` is correctly ignored after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)