### PR TITLE
Align resource key and data file environment variables

### DIFF
--- a/.github/workflows/nightly-pipeline.yml
+++ b/.github/workflows/nightly-pipeline.yml
@@ -47,16 +47,16 @@ jobs:
       cache-assets: true
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
+      DeviceDetection: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5BESPOKE }}
       DeviceDetectionUrl: ${{ secrets.DEVICE_DETECTION_URL }}
       CsvUrl: ${{ secrets.CSV_URL }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
-      TestSuperResourceKey: ${{ secrets.SUPER_RESOURCE_KEY }}
+      TestResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE}}
+      TestSuperResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE }}
       TestPlatformResourceKey: ${{ secrets.ACCEPTCH_PLATFORM_KEY }}
       TestHardwareResourceKey: ${{ secrets.ACCEPTCH_HARDWARE_KEY }}
       TestBrowserResourceKey: ${{ secrets.ACCEPTCH_BROWSER_KEY }}
       TestNoSetHeaderResourceKey: ${{ secrets.ACCEPTCH_NONE_KEY }}
-      TestLicenseKey: ${{ secrets.DEVICE_DETECTION_KEY }}
+      TestLicenseKey: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5BESPOKE }}
 
   Publish:
     if: ${{ !cancelled() }}
@@ -70,15 +70,15 @@ jobs:
       cache-assets: true
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
+      DeviceDetection: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5BESPOKE }}
       DeviceDetectionUrl: ${{ secrets.DEVICE_DETECTION_URL }}
       CsvUrl: ${{ secrets.CSV_URL }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
-      TestSuperResourceKey: ${{ secrets.SUPER_RESOURCE_KEY }}
+      TestResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE}}
+      TestSuperResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE }}
       TestPlatformResourceKey: ${{ secrets.ACCEPTCH_PLATFORM_KEY }}
       TestHardwareResourceKey: ${{ secrets.ACCEPTCH_HARDWARE_KEY }}
       TestBrowserResourceKey: ${{ secrets.ACCEPTCH_BROWSER_KEY }}
       TestNoSetHeaderResourceKey: ${{ secrets.ACCEPTCH_NONE_KEY }}
-      TestLicenseKey: ${{ secrets.DEVICE_DETECTION_KEY }}
+      TestLicenseKey: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5BESPOKE }}
       NPMAuthToken: ${{ secrets.NPM_AUTH_TOKEN}}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,14 +18,14 @@ jobs:
       cache-assets: true
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
+      DeviceDetection: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5BESPOKE }}
       DeviceDetectionUrl: ${{ secrets.DEVICE_DETECTION_URL }}
       CsvUrl: ${{ secrets.CSV_URL }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
-      TestSuperResourceKey: ${{ secrets.SUPER_RESOURCE_KEY }}
+      TestResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE}}
+      TestSuperResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE }}
       TestPlatformResourceKey: ${{ secrets.ACCEPTCH_PLATFORM_KEY }}
       TestHardwareResourceKey: ${{ secrets.ACCEPTCH_HARDWARE_KEY }}
       TestBrowserResourceKey: ${{ secrets.ACCEPTCH_BROWSER_KEY }}
       TestNoSetHeaderResourceKey: ${{ secrets.ACCEPTCH_NONE_KEY }}
-      TestLicenseKey: ${{ secrets.DEVICE_DETECTION_KEY }}
+      TestLicenseKey: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5BESPOKE }}
       NPMAuthToken: ${{ secrets.NPM_AUTH_TOKEN}}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -18,13 +18,13 @@ jobs:
       cache-assets: true
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
+      DeviceDetection: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5BESPOKE }}
       DeviceDetectionUrl: ${{ secrets.DEVICE_DETECTION_URL }}
       CsvUrl: ${{ secrets.CSV_URL }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
-      TestSuperResourceKey: ${{ secrets.SUPER_RESOURCE_KEY }}
+      TestResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE}}
+      TestSuperResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE }}
       TestPlatformResourceKey: ${{ secrets.ACCEPTCH_PLATFORM_KEY }}
       TestHardwareResourceKey: ${{ secrets.ACCEPTCH_HARDWARE_KEY }}
       TestBrowserResourceKey: ${{ secrets.ACCEPTCH_BROWSER_KEY }}
       TestNoSetHeaderResourceKey: ${{ secrets.ACCEPTCH_NONE_KEY }}
-      TestLicenseKey: ${{ secrets.DEVICE_DETECTION_KEY }}
+      TestLicenseKey: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5BESPOKE }}

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -74,6 +74,10 @@ Write-Output "Package configuration file created successfully."
 Pop-Location
 
 $env:RESOURCE_KEY = $Options.Keys.TestResourceKey
+# Aligned environment variable name. This is checked first by the examples
+# and tests. The legacy RESOURCE_KEY name above is retained for backwards
+# compatibility.
+${env:51DEGREES_RESOURCE_KEY} = $Options.Keys.TestResourceKey
 $env:TEST_SUPER_RESOURCE_KEY = $Options.Keys.TestSuperResourceKey
 $env:TEST_PLATFORM_RESOURCE_KEY = $Options.Keys.TestPlatformResourceKey
 $env:TEST_HARDWARE_RESOURCE_KEY = $Options.Keys.TestHardwareResourceKey

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -73,12 +73,8 @@ Write-Output "Package configuration file created successfully."
 
 Pop-Location
 
-$env:RESOURCE_KEY = $Options.Keys.TestResourceKey
-# Aligned environment variable name. This is checked first by the examples
-# and tests. The legacy RESOURCE_KEY name above is retained for backwards
-# compatibility.
-${env:51DEGREES_RESOURCE_KEY} = $Options.Keys.TestResourceKey
-$env:TEST_SUPER_RESOURCE_KEY = $Options.Keys.TestSuperResourceKey
+$env:_51DEGREES_RESOURCE_KEY = $Options.Keys.TestResourceKey
+$env:TEST_SUPER_RESOURCE_KEY = $Options.Keys.TestSuperResourceKey # currently the same as the key above
 $env:TEST_PLATFORM_RESOURCE_KEY = $Options.Keys.TestPlatformResourceKey
 $env:TEST_HARDWARE_RESOURCE_KEY = $Options.Keys.TestHardwareResourceKey
 $env:TEST_BROWSER_RESOURCE_KEY = $Options.Keys.TestBrowserResourceKey

--- a/fiftyone.devicedetection.cloud/examples/cloud/configurator-console/configurator.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/configurator-console/configurator.js
@@ -93,8 +93,8 @@ const run = async function (resourceKey, output) {
 // Don't run the server if under TEST
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
-  // Use the supplied resource key or try to obtain one from the environment variable.
-  const resourceKey = args.length > 0 ? args[0] : process.env[ExampleUtils.RESOURCE_KEY_ENV_VAR];
+  // Use the supplied resource key or try to obtain one from the environment variables.
+  const resourceKey = args.length > 0 ? args[0] : ExampleUtils.getResourceKeyFromEnv();
 
   // If we don't have a resource key then log an error
   if (!resourceKey) {

--- a/fiftyone.devicedetection.cloud/examples/cloud/configurator-console/configurator.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/configurator-console/configurator.js
@@ -102,9 +102,9 @@ if (process.env.JEST_WORKER_ID === undefined) {
       'No resource key specified on the command line or in the environment variable ' +
       `'${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud service is accessed ` +
       'using a \'ResourceKey\'. For more information see ' +
-      'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-configurator-console-configurator.js&utm_term=resource-key-required. A resource key with the ' +
-      'properties required by this example can be created for free at ' +
-      'https://configure.51degrees.com/g3gMZdPY?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-configurator-console-configurator.js&utm_term=resource-key-required. Once complete, populate the config file or ' +
+      'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-configurator-console-configurator.js&utm_term=resource-key-required. A free resource key ' +
+      'selecting the free properties used by this example can be created at ' +
+      'https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-configurator-console-configurator.js&utm_term=resource-key-required. Once complete, populate the config file or ' +
       'environment variable mentioned at the start of this message with the key.');
   } else {
     run(resourceKey, process.stdout);

--- a/fiftyone.devicedetection.cloud/examples/cloud/exampleUtils.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/exampleUtils.js
@@ -23,7 +23,7 @@
 // The default environment variable used to get the resource key
 // to use when running examples. This aligned name is checked first,
 // before the legacy variable name.
-const RESOURCE_KEY_ENV_VAR = '51DEGREES_RESOURCE_KEY';
+const RESOURCE_KEY_ENV_VAR = '_51DEGREES_RESOURCE_KEY';
 
 // The legacy environment variable used to get the resource key
 // to use when running examples. Retained for backwards compatibility
@@ -31,7 +31,7 @@ const RESOURCE_KEY_ENV_VAR = '51DEGREES_RESOURCE_KEY';
 const LEGACY_RESOURCE_KEY_ENV_VAR = 'RESOURCE_KEY';
 
 // Get the resource key from the environment. The aligned
-// '51DEGREES_RESOURCE_KEY' variable is checked first, followed by
+// '_51DEGREES_RESOURCE_KEY' variable is checked first, followed by
 // the legacy 'RESOURCE_KEY' variable.
 const getResourceKeyFromEnv = function () {
   return process.env[RESOURCE_KEY_ENV_VAR] ||
@@ -41,7 +41,7 @@ const getResourceKeyFromEnv = function () {
 // The common message shown when a resource key leaves one or more of
 // the properties used by an example without values.
 const PRICING_MESSAGE = 'Some properties used by this example are not ' +
-  'available with a free resource key. See https://51degrees.com/pricing ' +
+  'available with a free resource key. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-exampleutils.js&utm_term=resource-key-required ' +
   'to get a paid subscription with more properties.';
 
 module.exports = {

--- a/fiftyone.devicedetection.cloud/examples/cloud/exampleUtils.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/exampleUtils.js
@@ -38,8 +38,15 @@ const getResourceKeyFromEnv = function () {
     process.env[LEGACY_RESOURCE_KEY_ENV_VAR];
 };
 
+// The common message shown when a resource key leaves one or more of
+// the properties used by an example without values.
+const PRICING_MESSAGE = 'Some properties used by this example are not ' +
+  'available with a free resource key. See https://51degrees.com/pricing ' +
+  'to get a paid subscription with more properties.';
+
 module.exports = {
   RESOURCE_KEY_ENV_VAR,
   LEGACY_RESOURCE_KEY_ENV_VAR,
+  PRICING_MESSAGE,
   getResourceKeyFromEnv
 };

--- a/fiftyone.devicedetection.cloud/examples/cloud/exampleUtils.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/exampleUtils.js
@@ -21,9 +21,25 @@
  * ********************************************************************* */
 
 // The default environment variable used to get the resource key
-// to use when running examples.
-const RESOURCE_KEY_ENV_VAR = 'RESOURCE_KEY';
+// to use when running examples. This aligned name is checked first,
+// before the legacy variable name.
+const RESOURCE_KEY_ENV_VAR = '51DEGREES_RESOURCE_KEY';
+
+// The legacy environment variable used to get the resource key
+// to use when running examples. Retained for backwards compatibility
+// and checked when RESOURCE_KEY_ENV_VAR is not set.
+const LEGACY_RESOURCE_KEY_ENV_VAR = 'RESOURCE_KEY';
+
+// Get the resource key from the environment. The aligned
+// '51DEGREES_RESOURCE_KEY' variable is checked first, followed by
+// the legacy 'RESOURCE_KEY' variable.
+const getResourceKeyFromEnv = function () {
+  return process.env[RESOURCE_KEY_ENV_VAR] ||
+    process.env[LEGACY_RESOURCE_KEY_ENV_VAR];
+};
 
 module.exports = {
-  RESOURCE_KEY_ENV_VAR
+  RESOURCE_KEY_ENV_VAR,
+  LEGACY_RESOURCE_KEY_ENV_VAR,
+  getResourceKeyFromEnv
 };

--- a/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-console/gettingStarted.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-console/gettingStarted.js
@@ -93,17 +93,33 @@ const analyse = async function (evidence, pipeline, output) {
   // asking for the 'device' data.
   const device = data.device;
 
+  // Track whether any property is left without a value, which is
+  // usually because the resource key does not include the property.
+  let anyValueMissing = false;
+  const getValue = function (propertyName) {
+    try {
+      const property = device[propertyName];
+      if (!property || property.hasValue !== true) {
+        anyValueMissing = true;
+      }
+    } catch (e) {
+      anyValueMissing = true;
+    }
+    return DataExtension.getValueHelper(device, propertyName);
+  };
+
   // Display the results of the detection, which are called
   // device properties. See the property dictionary at
   // https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=analyse
   // for details of all available properties.
-  message += outputValue('Mobile Device', DataExtension.getValueHelper(device, 'ismobile'));
-  message += outputValue('Platform Name', DataExtension.getValueHelper(device, 'platformname'));
-  message += outputValue('Platform Version', DataExtension.getValueHelper(device, 'platformversion'));
-  message += outputValue('Browser Name', DataExtension.getValueHelper(device, 'browsername'));
-  message += outputValue('Browser Version', DataExtension.getValueHelper(device, 'browserversion'));
+  message += outputValue('Mobile Device', getValue('ismobile'));
+  message += outputValue('Platform Name', getValue('platformname'));
+  message += outputValue('Platform Version', getValue('platformversion'));
+  message += outputValue('Browser Name', getValue('browsername'));
+  message += outputValue('Browser Version', getValue('browserversion'));
   message += '\n\n';
   output.write(message);
+  return anyValueMissing;
 };
 
 const run = async function (options, output) {
@@ -117,10 +133,15 @@ const run = async function (options, output) {
       'service is accessed using a \'ResourceKey\'. For more information ' +
       'see ' +
       'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=resource-key-required. ' +
-      'A resource key with the properties required by this example can be ' +
-      'created for free at https://configure.51degrees.com/g3gMZdPY?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=resource-key-required. ' +
-      'Once complete, populate the config file or environment variable ' +
-      'mentioned at the start of this message with the key.'
+      'A resource key with the free properties used by this example can ' +
+      'be created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=resource-key-required. A free ' +
+      'key populates the free properties only, whilst a key created at ' +
+      'https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=resource-key-required also includes the paid ' +
+      'properties this example displays. See ' +
+      'https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=resource-key-required to get a paid subscription with ' +
+      'more properties. Once complete, populate the config file or ' +
+      'environment variable mentioned at the start of this message ' +
+      'with the key.'
     );
     return;
   }
@@ -132,8 +153,17 @@ const run = async function (options, output) {
   pipeline.on('error', console.error);
 
   // carry out some sample detections
+  let anyValueMissing = false;
   for (const values of exampleConstants.defaultEvidenceValues) {
-    await analyse(values, pipeline, output);
+    if (await analyse(values, pipeline, output)) {
+      anyValueMissing = true;
+    }
+  }
+
+  // If any property was left without a value then show the common
+  // pricing message once after the results.
+  if (anyValueMissing) {
+    output.write(ExampleUtils.PRICING_MESSAGE + '\n');
   }
 };
 

--- a/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-console/gettingStarted.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-console/gettingStarted.js
@@ -141,8 +141,8 @@ const run = async function (options, output) {
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
   // Use the supplied resource key or try to obtain one
-  // from the environment variable.
-  const resourceKey = args.length > 0 ? args[0] : process.env[ExampleUtils.RESOURCE_KEY_ENV_VAR];
+  // from the environment variables.
+  const resourceKey = args.length > 0 ? args[0] : ExampleUtils.getResourceKeyFromEnv();
 
   // Load the configuration from a config file to a JSON object.
   const options = JSON.parse(fs.readFileSync('51d.json'), 'utf8');

--- a/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-web/gettingStarted.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-web/gettingStarted.js
@@ -144,11 +144,16 @@ const setPipeline = (options) => {
     `'${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud ` +
     'service is accessed using a \'ResourceKey\'. For more information ' +
     'see ' +
-    'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required. ' +
-    'A resource key with the properties required by this example can be ' +
-    'created for free at https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required. ' +
-    'Once complete, populate the config file or environment variable ' +
-    'mentioned at the start of this message with the key.';
+    'https://51degrees.com/documentation/_info__resource_keys.html. ' +
+    'A resource key with the free properties used by this example can ' +
+    'be created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required. A free ' +
+    'key populates the free properties only, whilst a key created at ' +
+    'https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required also includes the paid ' +
+    'properties this example displays. See ' +
+    'https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required to get a paid subscription with ' +
+    'more properties. Once complete, populate the config file or ' +
+    'environment variable mentioned at the start of this message ' +
+    'with the key.';
   }
 
   pipeline = new core.PipelineBuilder({

--- a/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-web/gettingStarted.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-web/gettingStarted.js
@@ -240,9 +240,9 @@ const server = http.createServer((req, res) => {
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
   // Use the supplied resource key or try to obtain one
-  // from the environment variable.
+  // from the environment variables.
   const resourceKey =
-    args.length > 0 ? args[0] : process.env[ExampleUtils.RESOURCE_KEY_ENV_VAR];
+    args.length > 0 ? args[0] : ExampleUtils.getResourceKeyFromEnv();
 
   // Load the configuration options from
   const options = JSON.parse(fs.readFileSync(path.join(__dirname, '/51d.json')));

--- a/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-web/gettingStarted.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-web/gettingStarted.js
@@ -144,7 +144,7 @@ const setPipeline = (options) => {
     `'${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud ` +
     'service is accessed using a \'ResourceKey\'. For more information ' +
     'see ' +
-    'https://51degrees.com/documentation/_info__resource_keys.html. ' +
+    'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required. ' +
     'A resource key with the free properties used by this example can ' +
     'be created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required. A free ' +
     'key populates the free properties only, whilst a key created at ' +

--- a/fiftyone.devicedetection.cloud/examples/cloud/metadata-console/metaData.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/metadata-console/metaData.js
@@ -115,11 +115,11 @@ if (process.env.JEST_WORKER_ID === undefined) {
     'The 51Degrees cloud service is accessed using a \'ResourceKey\'. ' +
     'For more information ' +
     'see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-metadata-console-metadata.js&utm_term=resource-key-required. ' +
-    'Native model lookup is not available as a free service. This means that ' +
-    'you will first need a license key, which can be purchased from our ' +
-    'pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-metadata-console-metadata.js&utm_term=resource-key-required. Once this is done, a resource ' +
-    'key with the properties required by this example can be created at ' +
-    'https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-metadata-console-metadata.js&utm_term=resource-key-required. You can now populate the ' +
+    'Native model lookup requires a paid subscription. See ' +
+    'https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-metadata-console-metadata.js&utm_term=resource-key-required to get a paid subscription with more ' +
+    'properties. Once subscribed, a resource key with the properties ' +
+    'required by this example can be created at ' +
+    'https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-metadata-console-metadata.js&utm_term=resource-key-required. You can now populate the ' +
     'environment variable mentioned at the start of this message with the ' +
     'resource key or pass it as the first argument on the command line.');
   }

--- a/fiftyone.devicedetection.cloud/examples/cloud/metadata-console/metaData.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/metadata-console/metaData.js
@@ -104,8 +104,8 @@ const run = async function (resourceKey, output) {
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
   // Use the supplied resource key or try to obtain one
-  // from the environment variable.
-  const resourceKey = args.length > 0 ? args[0] : process.env[ExampleUtils.RESOURCE_KEY_ENV_VAR];
+  // from the environment variables.
+  const resourceKey = args.length > 0 ? args[0] : ExampleUtils.getResourceKeyFromEnv();
 
   if (resourceKey) {
     run(resourceKey, process.stdout);

--- a/fiftyone.devicedetection.cloud/examples/cloud/nativemodellookup-console/nativeModelLookup.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/nativemodellookup-console/nativeModelLookup.js
@@ -134,8 +134,8 @@ const run = async function (resourceKey, output) {
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
   // Use the supplied resource key or try to obtain one
-  // from the environment variable.
-  const resourceKey = args.length > 0 ? args[0] : process.env[ExampleUtils.RESOURCE_KEY_ENV_VAR];
+  // from the environment variables.
+  const resourceKey = args.length > 0 ? args[0] : ExampleUtils.getResourceKeyFromEnv();
 
   if (resourceKey) {
     run(resourceKey, process.stdout);

--- a/fiftyone.devicedetection.cloud/examples/cloud/nativemodellookup-console/nativeModelLookup.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/nativemodellookup-console/nativeModelLookup.js
@@ -145,11 +145,11 @@ if (process.env.JEST_WORKER_ID === undefined) {
     'The 51Degrees cloud service is accessed using a \'ResourceKey\'. ' +
     'For more information ' +
     'see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=resource-key-required. ' +
-    'Native model lookup is not available as a free service. This means that ' +
-    'you will first need a license key, which can be purchased from our ' +
-    'pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=resource-key-required. Once this is done, a resource ' +
-    'key with the properties required by this example can be created at ' +
-    'https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=resource-key-required. You can now populate the ' +
+    'Native model lookup requires a paid subscription. See ' +
+    'https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=resource-key-required to get a paid subscription with more ' +
+    'properties. Once subscribed, a resource key with the properties ' +
+    'required by this example can be created at ' +
+    'https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=resource-key-required. You can now populate the ' +
     'environment variable mentioned at the start of this message with the ' +
     'resource key or pass it as the first argument on the command line.');
   }

--- a/fiftyone.devicedetection.cloud/examples/cloud/taclookup-console/tacLookup.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/taclookup-console/tacLookup.js
@@ -95,11 +95,11 @@ const run = async function (options, output) {
       'service is accessed using a \'ResourceKey\'. For more information ' +
       'see ' +
       'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=resource-key-required. ' +
-      'TAC lookup is not available as a free service. This means that ' +
-      'you will first need a license key, which can be purchased from our ' +
-      'pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=resource-key-required. Once this is done, a resource ' +
-      'key with the properties required by this example can be created at ' +
-      'https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=resource-key-required. You can now populate the ' +
+      'TAC lookup requires a paid subscription. See ' +
+      'https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=resource-key-required to get a paid subscription with more ' +
+      'properties. Once subscribed, a resource key with the properties ' +
+      'required by this example can be created at ' +
+      'https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=resource-key-required. You can now populate the ' +
       'environment variable mentioned at the start of this message with the ' +
       'resource key or pass it as the first argument on the command line.'
     );

--- a/fiftyone.devicedetection.cloud/examples/cloud/taclookup-console/tacLookup.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/taclookup-console/tacLookup.js
@@ -135,8 +135,8 @@ const run = async function (options, output) {
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
   // Use the supplied resource key or try to obtain one
-  // from the environment variable.
-  const resourceKey = args.length > 0 ? args[0] : process.env[ExampleUtils.RESOURCE_KEY_ENV_VAR];
+  // from the environment variables.
+  const resourceKey = args.length > 0 ? args[0] : ExampleUtils.getResourceKeyFromEnv();
 
   // Load the configuration from a config file to a JSON object.
   const options = JSON.parse(fs.readFileSync('51d.json'), 'utf8');

--- a/fiftyone.devicedetection.cloud/examples/cloud/useragentclienthints-web/userAgentClientHintsWeb.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/useragentclienthints-web/userAgentClientHintsWeb.js
@@ -132,8 +132,10 @@ let server;
 let pipeline;
 const setPipeline = (resourceKey) => {
   // Create a new Device Detection pipeline and set the config.
-  // You need to create a resource key at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-useragentclienthints-web-useragentclienthintsweb.js&utm_term=setpipeline
-  // and paste it into the code.
+  // You need to create a resource key at
+  // https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-useragentclienthints-web-useragentclienthintsweb.js&utm_term=setpipeline
+  // and paste it into the code. This example displays paid properties, so a
+  // paid subscription is needed to populate them all.
   pipeline = new DeviceDetectionCloudPipelineBuilder({
     resourceKey
   }).build();
@@ -146,8 +148,11 @@ const setPipeline = (resourceKey) => {
 if (myResourceKey === '!!YOUR_RESOURCE_KEY!!' &&
   process.env.JEST_WORKER_ID === undefined) {
   console.log('You need to create a resource key at ' +
-        'https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-useragentclienthints-web-useragentclienthintsweb.js&utm_term=resource-key-required and paste it into the code, ' +
-        'replacing !!YOUR_RESOURCE_KEY!!');
+        'https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-useragentclienthints-web-useragentclienthintsweb.js&utm_term=resource-key-required and paste it into the ' +
+        'code, replacing !!YOUR_RESOURCE_KEY!!. This example displays ' +
+        'paid properties, so a paid subscription is needed to populate ' +
+        'them all. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-useragentclienthints-web-useragentclienthintsweb.js&utm_term=resource-key-required to get a paid ' +
+        'subscription with more properties.');
 } else {
   const http = require('http');
 

--- a/fiftyone.devicedetection.cloud/examples/cloud/useragentclienthints-web/userAgentClientHintsWeb.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/useragentclienthints-web/userAgentClientHintsWeb.js
@@ -119,7 +119,7 @@ const getValueHelper = (flowData, propertyKey) => {
   }
 };
 
-// The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
+// The aligned '_51DEGREES_RESOURCE_KEY' environment variable is checked
 // first, followed by the legacy 'RESOURCE_KEY' variable.
 const myResourceKey = ExampleUtils.getResourceKeyFromEnv() || '!!YOUR_RESOURCE_KEY!!';
 

--- a/fiftyone.devicedetection.cloud/examples/cloud/useragentclienthints-web/userAgentClientHintsWeb.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/useragentclienthints-web/userAgentClientHintsWeb.js
@@ -102,6 +102,8 @@ const core = require51('fiftyone.pipeline.core');
 
 const DeviceDetectionCloudPipelineBuilder = require51('fiftyone.devicedetection.cloud').DeviceDetectionCloudPipelineBuilder;
 
+const ExampleUtils = require(path.join(__dirname, '/../exampleUtils'));
+
 // Helper function to read property values from flowData
 const getValueHelper = (flowData, propertyKey) => {
   const device = flowData.device;
@@ -117,7 +119,9 @@ const getValueHelper = (flowData, propertyKey) => {
   }
 };
 
-const myResourceKey = process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
+// The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
+// first, followed by the legacy 'RESOURCE_KEY' variable.
+const myResourceKey = ExampleUtils.getResourceKeyFromEnv() || '!!YOUR_RESOURCE_KEY!!';
 
 // We need 'server' to be defined here so that, when this example
 // is executed as part of a unit test, the server can be closed

--- a/fiftyone.devicedetection.cloud/readme.md
+++ b/fiftyone.devicedetection.cloud/readme.md
@@ -5,7 +5,7 @@
 ## Introduction
 This project contains 51Degrees Device Detection engines that can be used with the [Pipeline API](https://github.com/51Degrees/pipeline-node).
 
-The Pipeline is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines) 
+The Pipeline is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines)
 
 ## This package - fiftyone.devicedetection.cloud
 
@@ -41,7 +41,7 @@ The tables below describe the examples that are available.
 
 ## Tests
 
-In this repository, there are tests for the examples. 
+In this repository, there are tests for the examples.
 You will need to install jest to run them:
 
 ```
@@ -50,7 +50,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-readme.md&utm_term=tests) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
+Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-readme.md&utm_term=tests) and assign it to the environment variable `51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `51DEGREES_RESOURCE_KEY`.
 
 There are other environment variables that you will also need to set in your test environment before running all tests:
 - `TEST_SUPER_RESOURCE_KEY`: This key contains all `SetHeader*` properties.

--- a/fiftyone.devicedetection.cloud/readme.md
+++ b/fiftyone.devicedetection.cloud/readme.md
@@ -50,7 +50,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-readme.md&utm_term=tests) and assign it to the environment variable `51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `51DEGREES_RESOURCE_KEY`.
+Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-readme.md&utm_term=tests) and assign it to the environment variable `_51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `_51DEGREES_RESOURCE_KEY`.
 
 There are other environment variables that you will also need to set in your test environment before running all tests:
 - `TEST_SUPER_RESOURCE_KEY`: This key contains all `SetHeader*` properties.

--- a/fiftyone.devicedetection.cloud/tests/deviceDetectionCloud.test.js
+++ b/fiftyone.devicedetection.cloud/tests/deviceDetectionCloud.test.js
@@ -49,7 +49,10 @@ const MobileUserAgent =
   'AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile' +
   '/11D167 Safari/9537.53';
 
-const myResourceKey = process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
+// The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
+// first, followed by the legacy 'RESOURCE_KEY' variable.
+const myResourceKey = process.env['51DEGREES_RESOURCE_KEY'] ||
+  process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
 
 describe('deviceDetectionCloud', () => {
   beforeAll(() => {

--- a/fiftyone.devicedetection.cloud/tests/deviceDetectionCloud.test.js
+++ b/fiftyone.devicedetection.cloud/tests/deviceDetectionCloud.test.js
@@ -49,9 +49,9 @@ const MobileUserAgent =
   'AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile' +
   '/11D167 Safari/9537.53';
 
-// The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
+// The aligned '_51DEGREES_RESOURCE_KEY' environment variable is checked
 // first, followed by the legacy 'RESOURCE_KEY' variable.
-const myResourceKey = process.env['51DEGREES_RESOURCE_KEY'] ||
+const myResourceKey = process.env['_51DEGREES_RESOURCE_KEY'] ||
   process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
 
 describe('deviceDetectionCloud', () => {

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/dataFileSystemWatcher.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/dataFileSystemWatcher.js
@@ -53,9 +53,10 @@ const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
 const args = process.argv.slice(2);
-// Use the supplied path for the data file or find the lite
-// file that is included in the repository.
-const datafile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
+// Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+// environment variable, or find the lite file that is included
+// in the repository.
+const datafile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);
 
 // Set your license key, if you don't have a license key already you can
 // obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-datafilesystemwatcher.js&utm_term=top

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/dataFileSystemWatcher.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/dataFileSystemWatcher.js
@@ -53,7 +53,7 @@ const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
 const args = process.argv.slice(2);
-// Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+// Use the supplied path for the data file, the '_51DEGREES_DD_PATH'
 // environment variable, or find the lite file that is included
 // in the repository.
 const datafile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updateOnStartUp.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updateOnStartUp.js
@@ -53,9 +53,10 @@ const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
 const args = process.argv.slice(2);
-// Use the supplied path for the data file or find the lite
-// file that is included in the repository.
-const datafile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
+// Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+// environment variable, or find the lite file that is included
+// in the repository.
+const datafile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);
 
 // Set your license key, if you don't have a license key already you can
 // obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updateonstartup.js&utm_term=top

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updateOnStartUp.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updateOnStartUp.js
@@ -53,7 +53,7 @@ const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
 const args = process.argv.slice(2);
-// Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+// Use the supplied path for the data file, the '_51DEGREES_DD_PATH'
 // environment variable, or find the lite file that is included
 // in the repository.
 const datafile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updatePollingInterval.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updatePollingInterval.js
@@ -53,9 +53,10 @@ const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
 const args = process.argv.slice(2);
-// Use the supplied path for the data file or find the lite
-// file that is included in the repository.
-const datafile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
+// Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+// environment variable, or find the lite file that is included
+// in the repository.
+const datafile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);
 
 // Set your license key, if you don't have a license key already you can
 // obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updatepollinginterval.js&utm_term=top

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updatePollingInterval.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updatePollingInterval.js
@@ -53,7 +53,7 @@ const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
 const args = process.argv.slice(2);
-// Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+// Use the supplied path for the data file, the '_51DEGREES_DD_PATH'
 // environment variable, or find the lite file that is included
 // in the repository.
 const datafile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/exampleUtils.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/exampleUtils.js
@@ -36,7 +36,7 @@ const DATA_FILE_AGE_WARNING = 30;
 // The environment variable that can be used to supply an explicit
 // path to the device detection data file. This is checked before
 // searching the folder hierarchy for the file.
-const DATA_FILE_PATH_ENV_VAR = '51DEGREES_DD_PATH';
+const DATA_FILE_PATH_ENV_VAR = '_51DEGREES_DD_PATH';
 
 class ExampleUtils {
   // Find the specified filename within the default lookup directory.

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/exampleUtils.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/exampleUtils.js
@@ -33,6 +33,11 @@ const FIND_FILE_TIMEOUT_MS = 10000;
 // be displayed.
 const DATA_FILE_AGE_WARNING = 30;
 
+// The environment variable that can be used to supply an explicit
+// path to the device detection data file. This is checked before
+// searching the folder hierarchy for the file.
+const DATA_FILE_PATH_ENV_VAR = '51DEGREES_DD_PATH';
+
 class ExampleUtils {
   // Find the specified filename within the default lookup directory.
   static findFile (fileName) {
@@ -40,6 +45,14 @@ class ExampleUtils {
       fileName,
       new Date().getTime() + FIND_FILE_TIMEOUT_MS,
       path.normalize(process.cwd()));
+  }
+
+  // Get the path to a device detection data file. The environment
+  // variable named by DATA_FILE_PATH_ENV_VAR is checked first for an
+  // explicit path. If it is not set then the folder hierarchy is
+  // searched for the supplied file name.
+  static findDataFile (fileName) {
+    return process.env[DATA_FILE_PATH_ENV_VAR] || this.findFile(fileName);
   }
 
   static isTimedOut (timeout) {
@@ -135,5 +148,6 @@ class ExampleUtils {
 
 module.exports = {
   ExampleUtils,
-  DATA_FILE_AGE_WARNING
+  DATA_FILE_AGE_WARNING,
+  DATA_FILE_PATH_ENV_VAR
 };

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.js
@@ -148,9 +148,10 @@ const run = async function (dataFile, output) {
 // Don't run the server if under TEST
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
-  // Use the supplied path for the data file or find the lite
-  // file that is included in the repository.
-  const dataFile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
+  // Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+  // environment variable, or find the lite file that is included
+  // in the repository.
+  const dataFile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);
 
   if (dataFile !== undefined) {
     run(dataFile, process.stdout);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.js
@@ -148,7 +148,7 @@ const run = async function (dataFile, output) {
 // Don't run the server if under TEST
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
-  // Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+  // Use the supplied path for the data file, the '_51DEGREES_DD_PATH'
   // environment variable, or find the lite file that is included
   // in the repository.
   const dataFile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.ts
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.ts
@@ -146,7 +146,7 @@ const run = async function (dataFile: string) {
 
 
 const args = process.argv.slice(2);
-// Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+// Use the supplied path for the data file, the '_51DEGREES_DD_PATH'
 // environment variable, or find the lite file that is included
 // in the repository.
 const dataFile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.ts
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.ts
@@ -41,6 +41,7 @@ type Pipeline = InstanceType<typeof fiftyone.Pipeline>;
 
 const ExampleUtils: {
   findFile: (fileName: string) => string | undefined;
+  findDataFile: (fileName: string) => string | undefined;
   checkDataFile: (pipeline: any, dataFile: string) => void;
 } = _eu;
 
@@ -145,9 +146,10 @@ const run = async function (dataFile: string) {
 
 
 const args = process.argv.slice(2);
-// Use the supplied path for the data file or find the lite
-// file that is included in the repository.
-const dataFile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
+// Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+// environment variable, or find the lite file that is included
+// in the repository.
+const dataFile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);
 
 if (dataFile !== undefined) {
   run(dataFile);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-web/gettingStarted.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-web/gettingStarted.js
@@ -133,16 +133,24 @@ const optionsExtension =
 const dataExtension =
   require51('fiftyone.devicedetection.shared').dataExtension;
 
-const { DATA_FILE_AGE_WARNING, ExampleUtils } =
+const { DATA_FILE_AGE_WARNING, DATA_FILE_PATH_ENV_VAR, ExampleUtils } =
   require(path.join(__dirname, '/../exampleUtils'));
 
 // Pipeline variable to be used
 let pipeline;
 
 const setPipeline = (options) => {
+  // An explicit data file path supplied in the '51DEGREES_DD_PATH'
+  // environment variable takes precedence over the value in the
+  // configuration file.
+  const envDataFilePath = process.env[DATA_FILE_PATH_ENV_VAR];
+  if (envDataFilePath) {
+    optionsExtension.setDataFilePath(options, envDataFilePath);
+  }
   const dataFilePath = optionsExtension.getDataFilePath(options);
   if (!dataFilePath) {
-    throw 'A data file must be specified in the 51d.json file.';
+    throw 'A data file must be specified in the 51d.json file or the ' +
+      `'${DATA_FILE_PATH_ENV_VAR}' environment variable.`;
   }
 
   if (!fs.existsSync(dataFilePath)) {

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-web/gettingStarted.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-web/gettingStarted.js
@@ -140,7 +140,7 @@ const { DATA_FILE_AGE_WARNING, DATA_FILE_PATH_ENV_VAR, ExampleUtils } =
 let pipeline;
 
 const setPipeline = (options) => {
-  // An explicit data file path supplied in the '51DEGREES_DD_PATH'
+  // An explicit data file path supplied in the '_51DEGREES_DD_PATH'
   // environment variable takes precedence over the value in the
   // configuration file.
   const envDataFilePath = process.env[DATA_FILE_PATH_ENV_VAR];

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/matchmetrics-console/matchMetrics.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/matchmetrics-console/matchMetrics.js
@@ -54,7 +54,8 @@ const fs = require('fs');
 const DeviceDetectionOnPremisePipelineBuilder =
   require51('fiftyone.devicedetection.onpremise').DeviceDetectionOnPremisePipelineBuilder;
 
-const ExampleUtils = require(path.join(__dirname, '/../exampleUtils')).ExampleUtils;
+const { ExampleUtils, DATA_FILE_PATH_ENV_VAR } =
+  require(path.join(__dirname, '/../exampleUtils'));
 const exampleConstants = require51('fiftyone.devicedetection.shared').exampleConstants;
 
 // In this example, by default, the 51degrees "Lite" file needs to be in the
@@ -156,14 +157,15 @@ const groupBy = function (list, keyGetter) {
 };
 
 const findDataFile = function (dataFile, output) {
-  // No filename specified use the default
+  // No filename specified. Check the environment variable for an explicit
+  // path, then search the folder hierarchy for the default file name.
   if (dataFile === null) {
-    dataFile = LITE_V_4_1_HASH;
-    output.write(`No filename specified. Using default '${dataFile}'\n`);
-  }
-
-  // Work out where the data file is if we don't have an absolute path.
-  if (path.isAbsolute(dataFile) === false) {
+    output.write('No filename specified. Checking the ' +
+      `'${DATA_FILE_PATH_ENV_VAR}' environment variable, then searching ` +
+      `for the default '${LITE_V_4_1_HASH}'\n`);
+    dataFile = ExampleUtils.findDataFile(LITE_V_4_1_HASH);
+  } else if (path.isAbsolute(dataFile) === false) {
+    // Work out where the data file is if we don't have an absolute path.
     dataFile = ExampleUtils.findFile(dataFile);
   }
 

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/metadata-console/metaData.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/metadata-console/metaData.js
@@ -200,9 +200,10 @@ const run = async function (dataFile, output) {
 // Don't run the server if under TEST
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
-  // Use the supplied path for the data file or find the lite
-  // file that is included in the repository.
-  const dataFile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
+  // Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+  // environment variable, or find the lite file that is included
+  // in the repository.
+  const dataFile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);
 
   if (dataFile !== undefined) {
     run(dataFile, process.stdout);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/metadata-console/metaData.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/metadata-console/metaData.js
@@ -200,7 +200,7 @@ const run = async function (dataFile, output) {
 // Don't run the server if under TEST
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
-  // Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+  // Use the supplied path for the data file, the '_51DEGREES_DD_PATH'
   // environment variable, or find the lite file that is included
   // in the repository.
   const dataFile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/offlineprocessing-console/offlineProcessing.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/offlineprocessing-console/offlineProcessing.js
@@ -208,7 +208,7 @@ const run = async function (dataFile, evidenceFile, outputFile, outputFunc) {
 // Don't run the server if under TEST
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
-  // Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+  // Use the supplied path for the data file, the '_51DEGREES_DD_PATH'
   // environment variable, or find the lite file that is included
   // in the repository.
   const dataFile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/offlineprocessing-console/offlineProcessing.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/offlineprocessing-console/offlineProcessing.js
@@ -208,9 +208,10 @@ const run = async function (dataFile, evidenceFile, outputFile, outputFunc) {
 // Don't run the server if under TEST
 if (process.env.JEST_WORKER_ID === undefined) {
   const args = process.argv.slice(2);
-  // Use the supplied path for the data file or find the lite
-  // file that is included in the repository.
-  const dataFile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
+  // Use the supplied path for the data file, the '51DEGREES_DD_PATH'
+  // environment variable, or find the lite file that is included
+  // in the repository.
+  const dataFile = args.length > 0 ? args[0] : ExampleUtils.findDataFile(LITE_V_4_1_HASH);
   // Do the same for the yaml evidence file
   const evidenceFile = args.length > 1 ? args[1] : ExampleUtils.findFile(EVIDENCE);
   // Finally, get the location for the output file. Use the same location as the

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/performance-console/performance.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/performance-console/performance.js
@@ -87,7 +87,7 @@ const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 const UA_CSV = '20000 User Agents.csv';
 
 const args = parser.parse_args();
-const datafile = args.datafile !== undefined ? args.datafile : ExampleUtils.findFile(LITE_V_4_1_HASH);
+const datafile = args.datafile !== undefined ? args.datafile : ExampleUtils.findDataFile(LITE_V_4_1_HASH);
 const uafile = args.evidence !== undefined ? args.evidence : ExampleUtils.findFile(UA_CSV);
 const jsonoutput = args.jsonoutput;
 

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/updatedatafile-console/updatedatafile.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/updatedatafile-console/updatedatafile.js
@@ -36,7 +36,8 @@ const AutoUpdateStatus = require('fiftyone.pipeline.engines').AutoUpdateStatus;
 const DeviceDetectionOnPremisePipelineBuilder =
   require51('fiftyone.devicedetection.onpremise').DeviceDetectionOnPremisePipelineBuilder;
 
-const ExampleUtils = require(path.join(__dirname, '/../exampleUtils')).ExampleUtils;
+const { ExampleUtils, DATA_FILE_PATH_ENV_VAR } =
+  require(path.join(__dirname, '/../exampleUtils'));
 const ExampleConstants = require51('fiftyone.devicedetection.shared').exampleConstants;
 const KeyUtils = require51('fiftyone.devicedetection.shared').keyUtils;
 
@@ -202,7 +203,11 @@ const run = async function (dataFilePath, licenseKey, interactive, output) {
         'start-up');
     }
   }
-  // no filename specified use the default
+  // no filename specified, check the environment variable for an
+  // explicit path before falling back to the default
+  if (!dataFilePath) {
+    dataFilePath = process.env[DATA_FILE_PATH_ENV_VAR];
+  }
   if (!dataFilePath) {
     dataFilePath = DEFAULT_DATA_FILENAME;
     console.warn(`No filename specified. Using default '${dataFilePath}' which will be downloaded to ` +

--- a/fiftyone.devicedetection/examples/gettingStarted.js
+++ b/fiftyone.devicedetection/examples/gettingStarted.js
@@ -52,8 +52,11 @@ const DeviceDetectionPipelineBuilder = require51('fiftyone.devicedetection').Dev
 
 // Create the device detection pipeline with the desired settings.
 
-// You need to create a resource key at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-examples-gettingstarted.js&utm_term=top
-// and paste it into the code, replacing !!YOUR_RESOURCE_KEY!! below.
+// You need to create a resource key at
+// https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-examples-gettingstarted.js&utm_term=top
+// and paste it into the code, replacing !!YOUR_RESOURCE_KEY!! below. The link
+// selects the free properties, which include the ismobile property used by
+// this example.
 
 // The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
 // first, followed by the legacy 'RESOURCE_KEY' variable.
@@ -62,8 +65,8 @@ const myResourceKey = process.env['51DEGREES_RESOURCE_KEY'] ||
 
 if (myResourceKey === '!!YOUR_RESOURCE_KEY!!') {
   console.log('You need to create a resource key at ' +
-        'https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-examples-gettingstarted.js&utm_term=resource-key-required and paste it into the code, ' +
-        'replacing !!YOUR_RESOURCE_KEY!!');
+        'https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-examples-gettingstarted.js&utm_term=resource-key-required and paste it into ' +
+        'the code, replacing !!YOUR_RESOURCE_KEY!!');
   console.log('Make sure to include the ismobile property ' +
         'as it is used by this example.');
 } else {

--- a/fiftyone.devicedetection/examples/gettingStarted.js
+++ b/fiftyone.devicedetection/examples/gettingStarted.js
@@ -58,9 +58,9 @@ const DeviceDetectionPipelineBuilder = require51('fiftyone.devicedetection').Dev
 // selects the free properties, which include the ismobile property used by
 // this example.
 
-// The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
+// The aligned '_51DEGREES_RESOURCE_KEY' environment variable is checked
 // first, followed by the legacy 'RESOURCE_KEY' variable.
-const myResourceKey = process.env['51DEGREES_RESOURCE_KEY'] ||
+const myResourceKey = process.env['_51DEGREES_RESOURCE_KEY'] ||
   process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
 
 if (myResourceKey === '!!YOUR_RESOURCE_KEY!!') {

--- a/fiftyone.devicedetection/examples/gettingStarted.js
+++ b/fiftyone.devicedetection/examples/gettingStarted.js
@@ -55,7 +55,10 @@ const DeviceDetectionPipelineBuilder = require51('fiftyone.devicedetection').Dev
 // You need to create a resource key at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-examples-gettingstarted.js&utm_term=top
 // and paste it into the code, replacing !!YOUR_RESOURCE_KEY!! below.
 
-const myResourceKey = process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
+// The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
+// first, followed by the legacy 'RESOURCE_KEY' variable.
+const myResourceKey = process.env['51DEGREES_RESOURCE_KEY'] ||
+  process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
 
 if (myResourceKey === '!!YOUR_RESOURCE_KEY!!') {
   console.log('You need to create a resource key at ' +

--- a/fiftyone.devicedetection/readme.md
+++ b/fiftyone.devicedetection/readme.md
@@ -45,7 +45,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-You need to obtain a 51Degrees cloud resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-readme.md&utm_term=tests) and assign it to the environment variable `51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `51DEGREES_RESOURCE_KEY`.
+You need to obtain a 51Degrees cloud resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-readme.md&utm_term=tests) and assign it to the environment variable `_51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `_51DEGREES_RESOURCE_KEY`.
 
 To run the tests, navigate to the module directory and execute:
 

--- a/fiftyone.devicedetection/readme.md
+++ b/fiftyone.devicedetection/readme.md
@@ -5,7 +5,7 @@
 ## Introduction
 This project contains 51Degrees Device Detection engines that can be used with the [Pipeline API](https://github.com/51Degrees/pipeline-node).
 
-The Pipeline is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines) 
+The Pipeline is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines)
 
 ## This package - fiftyone.devicedetection
 
@@ -36,7 +36,7 @@ The tables below describe the examples that are available.
 
 ## Tests
 
-In this repository, there are tests for the examples. 
+In this repository, there are tests for the examples.
 You will need to install jest to run them:
 
 ```
@@ -45,7 +45,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-You need to obtain a 51Degrees cloud resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-readme.md&utm_term=tests) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
+You need to obtain a 51Degrees cloud resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-readme.md&utm_term=tests) and assign it to the environment variable `51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `51DEGREES_RESOURCE_KEY`.
 
 To run the tests, navigate to the module directory and execute:
 

--- a/fiftyone.devicedetection/tests/deviceDetectionCloud.test.js
+++ b/fiftyone.devicedetection/tests/deviceDetectionCloud.test.js
@@ -29,9 +29,9 @@ const require51 = (requestedPackage) => {
 };
 
 const DeviceDetectionPipelineBuilder = require51('fiftyone.devicedetection').DeviceDetectionPipelineBuilder;
-// The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
+// The aligned '_51DEGREES_RESOURCE_KEY' environment variable is checked
 // first, followed by the legacy 'RESOURCE_KEY' variable.
-const myResourceKey = process.env['51DEGREES_RESOURCE_KEY'] ||
+const myResourceKey = process.env['_51DEGREES_RESOURCE_KEY'] ||
   process.env.RESOURCE_KEY;
 const errorMessages = require51('fiftyone.devicedetection.shared').errorMessages;
 

--- a/fiftyone.devicedetection/tests/deviceDetectionCloud.test.js
+++ b/fiftyone.devicedetection/tests/deviceDetectionCloud.test.js
@@ -29,7 +29,10 @@ const require51 = (requestedPackage) => {
 };
 
 const DeviceDetectionPipelineBuilder = require51('fiftyone.devicedetection').DeviceDetectionPipelineBuilder;
-const myResourceKey = process.env.RESOURCE_KEY;
+// The aligned '51DEGREES_RESOURCE_KEY' environment variable is checked
+// first, followed by the legacy 'RESOURCE_KEY' variable.
+const myResourceKey = process.env['51DEGREES_RESOURCE_KEY'] ||
+  process.env.RESOURCE_KEY;
 const errorMessages = require51('fiftyone.devicedetection.shared').errorMessages;
 
 describe('deviceDetectionCloud', () => {

--- a/readme.md
+++ b/readme.md
@@ -45,15 +45,15 @@ the following device properties used by the examples: IsMobile, DeviceType,
 ScreenPixelsWidth, ScreenPixelsHeight, ScreenPixelsHeightJavaScript, the three
 `SetHeader*Accept-CH` properties, JavascriptGetHighEntropyValues, IsCrawler,
 DeviceId and UserAgents. A resource key that selects these free properties can be
-created at [https://configure.51degrees.com/Wkqxf3Bs](https://configure.51degrees.com/Wkqxf3Bs).
+created [here](https://configure.51degrees.com/Wkqxf3Bs?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud).
 
 The paid device properties used by the examples are: HardwareVendor, HardwareName,
 HardwareModel, PlatformVendor, PlatformName, PlatformVersion, BrowserVendor,
 BrowserName, BrowserVersion, ScreenPixelsWidthJavaScript and
 JavascriptHardwareProfile, plus the TAC and native model hardware profiles. A
 resource key that selects the free properties plus these paid properties can be
-created at [https://configure.51degrees.com/hYzn3TV3](https://configure.51degrees.com/hYzn3TV3).
-See https://51degrees.com/pricing to get a paid subscription with more properties.
+created [here](https://configure.51degrees.com/hYzn3TV3?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud).
+See [pricing](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud) to get a paid subscription with more properties.
 
 #### On-Premise
 
@@ -64,7 +64,7 @@ properties see the [51Degrees website](https://51degrees.com/pricing?utm_source=
 
 The on-premise examples locate the data file in the following order:
 
-1. The `51DEGREES_DD_PATH` environment variable, which can be set to an explicit path to the
+1. The `_51DEGREES_DD_PATH` environment variable, which can be set to an explicit path to the
    data file.
 2. A search of the folder hierarchy, walking up from the working directory, for the expected
    file name.
@@ -200,7 +200,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=tests) and assign it to the environment variable `51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `51DEGREES_RESOURCE_KEY`.
+Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=tests) and assign it to the environment variable `_51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `_51DEGREES_RESOURCE_KEY`.
 
 There are other environment variables that you will also need to set in your test environment before running all tests:
 - `TEST_SUPER_RESOURCE_KEY`: This key contains all `SetHeader*` properties.

--- a/readme.md
+++ b/readme.md
@@ -5,11 +5,11 @@
 ## Introduction
 This project contains 51Degrees Device Detection engines that can be used with the [Pipeline API](https://github.com/51Degrees/pipeline-node).
 
-The Pipeline is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines) 
+The Pipeline is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines)
 
 ## Device detection
 
-Device detection can be performed 'on-premise' using a local data file or via the 51Degrees cloud service. 
+Device detection can be performed 'on-premise' using a local data file or via the 51Degrees cloud service.
 On-premise provides better performance, while cloud is easier to deploy.
 
 Both options use the same evidence values and expose (almost all) the same properties, so can be swapped out if needed at a later date.
@@ -24,8 +24,8 @@ Both options use the same evidence values and expose (almost all) the same prope
 ### Dependencies
 
 For runtime dependencies, see our [dependencies](https://51degrees.com/documentation/_info__dependencies.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=dependencies) page.
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=dependencies) page shows 
-the Node versions that we currently test against. The software may run fine against other 
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=dependencies) page shows
+the Node versions that we currently test against. The software may run fine against other
 versions, but additional caution should be applied.
 
 ### Data
@@ -35,16 +35,28 @@ The API can either use our cloud service to get its data or it can use a local (
 #### Cloud
 
 You will require a [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud)
-to use the Cloud API. You can create resource keys using our 
-[configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud), see our 
+to use the Cloud API. You can create resource keys using our
+[configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud), see our
 [documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud) on how to use this.
 
 #### On-Premise
 
-In order to perform device detection on-premise, you will need to use a 51Degrees data file. 
-This repository includes a free, 'lite' file in the 'device-detection-data' sub-module that has a 
-significantly reduced set of properties. To obtain a file with a more complete set of device 
-properties see the [51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=on-premise). If you want to use the lite 
+In order to perform device detection on-premise, you will need to use a 51Degrees data file.
+This repository includes a free, 'lite' file in the 'device-detection-data' sub-module that has a
+significantly reduced set of properties. To obtain a file with a more complete set of device
+properties see the [51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=on-premise).
+
+The on-premise examples locate the data file in the following order:
+
+1. The `51DEGREES_DD_PATH` environment variable, which can be set to an explicit path to the
+   data file.
+2. A search of the folder hierarchy, walking up from the working directory, for the expected
+   file name.
+3. The free 'Lite' data file in its expected location, which is the
+   'fiftyone.devicedetection.onpremise/device-detection-cxx/device-detection-data' sub-module
+   of this repository.
+
+If you want to use the lite
 file, you will need to install [GitLFS](https://git-lfs.github.com/):
 
 ```
@@ -72,8 +84,8 @@ npm install fiftyone.devicedetection.onpremise
 
 ### Build from Source On-Premise
 
-Device detection on-premise uses a native binary. (i.e. compiled from C code to target a specific 
-platform/architecture) The NPM package contains several binaries for common platforms. However, 
+Device detection on-premise uses a native binary. (i.e. compiled from C code to target a specific
+platform/architecture) The NPM package contains several binaries for common platforms. However,
 in some cases, you'll need to build the native binaries yourself for your target platform. This
 section explains how to do this.
 
@@ -81,7 +93,7 @@ section explains how to do this.
 
 - Install Node.js.
 - Install node-gyp by running.
-  - `npm install node-gyp --global`  
+  - `npm install node-gyp --global`
 - Install C build tools:
   - Windows:
     - You will need either Visual Studio 2019 or the [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) installed.
@@ -92,7 +104,7 @@ section explains how to do this.
 - Pull git submodules:
   - `git submodule update --init --recursive`
 
-#### Build Steps 
+#### Build Steps
 
 - Navigate to fiftyone.devicedetection.onpremise
 - Rename the `binding.51d` to `binding.gyp`
@@ -163,7 +175,7 @@ The tables below describe the examples that are available.
 
 ## Tests
 
-In this repository, there are tests for the examples. 
+In this repository, there are tests for the examples.
 You will need to install jest to run them:
 
 ```
@@ -172,7 +184,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=tests) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
+Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=tests) and assign it to the environment variable `51DEGREES_RESOURCE_KEY` in your test environment. The legacy environment variable name `RESOURCE_KEY` is still supported and is checked second, after `51DEGREES_RESOURCE_KEY`.
 
 There are other environment variables that you will also need to set in your test environment before running all tests:
 - `TEST_SUPER_RESOURCE_KEY`: This key contains all `SetHeader*` properties.
@@ -189,7 +201,7 @@ npm test
 
 ## Native code updates
 
-Process for rebuilding SWIG interfaces following an update to the device detection cxx code 
+Process for rebuilding SWIG interfaces following an update to the device detection cxx code
 (This is only intended to be run by 51Degrees developers internally):
 
 1. Ensure Swig is installed.
@@ -210,9 +222,9 @@ Process for rebuilding SWIG interfaces following an update to the device detecti
 
 Types are generated and exported automatically from JSDoc comments using [this script](https://github.com/51Degrees/common-ci/blob/main/node/generate-types.ps1#L10). Upon generation types are committed into the repository into the package's `types` directory. Calling the generation step is manual for now, but later will be added as part of CI/CD pipeline.
 
-The TypeScript example with typechecking enabled is available under `onpremise/gettingstarted-console/gettingStarted.ts`. 
+The TypeScript example with typechecking enabled is available under `onpremise/gettingstarted-console/gettingStarted.ts`.
 
-The example can be run as: 
+The example can be run as:
 
 ```
 npx ts-node gettingStarted.ts

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,22 @@ to use the Cloud API. You can create resource keys using our
 [configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud), see our
 [documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud) on how to use this.
 
+The cloud property tiers changed in May 2026. The examples and this documentation
+now reflect what is free and what needs a paid subscription. The free tier includes
+the following device properties used by the examples: IsMobile, DeviceType,
+ScreenPixelsWidth, ScreenPixelsHeight, ScreenPixelsHeightJavaScript, the three
+`SetHeader*Accept-CH` properties, JavascriptGetHighEntropyValues, IsCrawler,
+DeviceId and UserAgents. A resource key that selects these free properties can be
+created at [https://configure.51degrees.com/Wkqxf3Bs](https://configure.51degrees.com/Wkqxf3Bs).
+
+The paid device properties used by the examples are: HardwareVendor, HardwareName,
+HardwareModel, PlatformVendor, PlatformName, PlatformVersion, BrowserVendor,
+BrowserName, BrowserVersion, ScreenPixelsWidthJavaScript and
+JavascriptHardwareProfile, plus the TAC and native model hardware profiles. A
+resource key that selects the free properties plus these paid properties can be
+created at [https://configure.51degrees.com/hYzn3TV3](https://configure.51degrees.com/hYzn3TV3).
+See https://51degrees.com/pricing to get a paid subscription with more properties.
+
 #### On-Premise
 
 In order to perform device detection on-premise, you will need to use a 51Degrees data file.


### PR DESCRIPTION
## Summary

This change aligns the environment variable names used by the examples with the convention shared across 51Degrees repositories.

- The resource key is read from `51DEGREES_RESOURCE_KEY` first. The legacy `RESOURCE_KEY` name is retained and checked second, so existing setups keep working.
- An explicit data file path can be supplied in `51DEGREES_DD_PATH`, which is checked before the folder hierarchy is walked to find the expected file name. The free Lite data file in the device-detection-cxx/device-detection-data submodule remains the final fallback.
- Developer-facing messages now reference the aligned names and the readmes document the resolution order.
- The CI setup script also sets the aligned resource key name, with the legacy assignment retained.

## Notes

- Test-specific keys such as `TEST_SUPER_RESOURCE_KEY` and the `ACCEPTCH_*` keys are deliberate per-purpose keys and are unchanged.
- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned names start with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set them with the env command, for example `env 51DEGREES_RESOURCE_KEY=AAA node gettingStarted.js`.
