### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,9 +4,9 @@ This API complies with the `common-ci` approach.
 The following secrets are required:
 * `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
 * `NPM_AUTH_TOKEN` - [NPM token](https://docs.npmjs.com/creating-and-viewing-access-tokens)  for publishing packages
     * Example: `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`

--- a/fiftyone.devicedetection.cloud/deviceDetectionCloudPipelineBuilder.js
+++ b/fiftyone.devicedetection.cloud/deviceDetectionCloudPipelineBuilder.js
@@ -38,7 +38,7 @@ class DeviceDetectionCloudPipelineBuilder extends PipelineBuilder {
    * @param {object} options the options for the pipeline builder
    * @param {string} options.licenceKeys license key(s) used by the
    * data file update service. A key can be obtained from the
-   * 51Degrees website: https://51degrees.com/pricing.
+   * 51Degrees website: https://51degrees.com/pricing?utm_source=code&utm_medium=comment&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-devicedetectioncloudpipelinebuilder.js&utm_term=constructor.
    * This parameter MUST be set when using a data file.
    * If you do not wish to use a key then you can specify
    * an empty string, but this will cause automatic updates

--- a/fiftyone.devicedetection.cloud/examples/cloud/configurator-console/configurator.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/configurator-console/configurator.js
@@ -21,13 +21,13 @@
  * ********************************************************************* */
 
 /**
- * This example is displayed at the end of the [Configurator](https://configure.51degrees.com/)
+ * This example is displayed at the end of the [Configurator](https://configure.51degrees.com/?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-configurator-console-configurator.js&utm_term=header)
  * process, which is used to create resource keys for use with the 51Degrees cloud service.
  *
  * It shows how to call the cloud with the newly created key and how to access the values
  * of the selected properties.
  *
- * See [Getting Started](https://51degrees.com/documentation/_examples__device_detection__getting_started__console__cloud.html)
+ * See [Getting Started](https://51degrees.com/documentation/_examples__device_detection__getting_started__console__cloud.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-configurator-console-configurator.js&utm_term=header)
  * for a fuller example.
  *
  * Required npm Dependencies:
@@ -102,9 +102,9 @@ if (process.env.JEST_WORKER_ID === undefined) {
       'No resource key specified on the command line or in the environment variable ' +
       `'${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud service is accessed ` +
       'using a \'ResourceKey\'. For more information see ' +
-      'https://51degrees.com/documentation/_info__resource_keys.html. A resource key with the ' +
+      'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-configurator-console-configurator.js&utm_term=resource-key-required. A resource key with the ' +
       'properties required by this example can be created for free at ' +
-      'https://configure.51degrees.com/g3gMZdPY. Once complete, populate the config file or ' +
+      'https://configure.51degrees.com/g3gMZdPY?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-configurator-console-configurator.js&utm_term=resource-key-required. Once complete, populate the config file or ' +
       'environment variable mentioned at the start of this message with the key.');
   } else {
     run(resourceKey, process.stdout);

--- a/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-console/gettingStarted.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-console/gettingStarted.js
@@ -95,7 +95,7 @@ const analyse = async function (evidence, pipeline, output) {
 
   // Display the results of the detection, which are called
   // device properties. See the property dictionary at
-  // https://51degrees.com/developers/property-dictionary
+  // https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=analyse
   // for details of all available properties.
   message += outputValue('Mobile Device', DataExtension.getValueHelper(device, 'ismobile'));
   message += outputValue('Platform Name', DataExtension.getValueHelper(device, 'platformname'));
@@ -116,9 +116,9 @@ const run = async function (options, output) {
       `'${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud ` +
       'service is accessed using a \'ResourceKey\'. For more information ' +
       'see ' +
-      'https://51degrees.com/documentation/_info__resource_keys.html. ' +
+      'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=resource-key-required. ' +
       'A resource key with the properties required by this example can be ' +
-      'created for free at https://configure.51degrees.com/g3gMZdPY. ' +
+      'created for free at https://configure.51degrees.com/g3gMZdPY?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-console-gettingstarted.js&utm_term=resource-key-required. ' +
       'Once complete, populate the config file or environment variable ' +
       'mentioned at the start of this message with the key.'
     );

--- a/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-web/gettingStarted.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/gettingstarted-web/gettingStarted.js
@@ -100,9 +100,9 @@ const setPipeline = (options) => {
     `'${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud ` +
     'service is accessed using a \'ResourceKey\'. For more information ' +
     'see ' +
-    'https://51degrees.com/documentation/_info__resource_keys.html. ' +
+    'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required. ' +
     'A resource key with the properties required by this example can be ' +
-    'created for free at https://configure.51degrees.com/1QWJwHxl. ' +
+    'created for free at https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=resource-key-required. ' +
     'Once complete, populate the config file or environment variable ' +
     'mentioned at the start of this message with the key.';
   }
@@ -151,7 +151,7 @@ const server = http.createServer((req, res) => {
       // requested. So set whatever headers are required by the browser in
       // order to return the evidence needed by the pipeline.
       // More info on this can be found at
-      // https://51degrees.com/blog/user-agent-client-hints
+      // https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-gettingstarted-web-gettingstarted.js&utm_term=server
       core.Helpers.setResponseHeaders(res, flowData);
 
       // Obtain all used evidence

--- a/fiftyone.devicedetection.cloud/examples/cloud/metadata-console/metaData.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/metadata-console/metaData.js
@@ -114,12 +114,12 @@ if (process.env.JEST_WORKER_ID === undefined) {
     `the environment variable '${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. ` +
     'The 51Degrees cloud service is accessed using a \'ResourceKey\'. ' +
     'For more information ' +
-    'see https://51degrees.com/documentation/_info__resource_keys.html. ' +
+    'see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-metadata-console-metadata.js&utm_term=resource-key-required. ' +
     'Native model lookup is not available as a free service. This means that ' +
     'you will first need a license key, which can be purchased from our ' +
-    'pricing page: https://51degrees.com/pricing. Once this is done, a resource ' +
+    'pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-metadata-console-metadata.js&utm_term=resource-key-required. Once this is done, a resource ' +
     'key with the properties required by this example can be created at ' +
-    'https://configure.51degrees.com/1QWJwHxl. You can now populate the ' +
+    'https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-metadata-console-metadata.js&utm_term=resource-key-required. You can now populate the ' +
     'environment variable mentioned at the start of this message with the ' +
     'resource key or pass it as the first argument on the command line.');
   }

--- a/fiftyone.devicedetection.cloud/examples/cloud/nativemodellookup-console/nativeModelLookup.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/nativemodellookup-console/nativeModelLookup.js
@@ -103,7 +103,7 @@ const run = async function (resourceKey, output) {
   // This example creates the pipeline and engines in code. For a demonstration
   // of how to do this using a configuration file instead, see the TacLookup example.
   // For more information about builders in general see the documentation at
-  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=run
   const requestEngineInstance = new CloudRequestEngine.CloudRequestEngine({
     resourceKey
   });
@@ -144,12 +144,12 @@ if (process.env.JEST_WORKER_ID === undefined) {
     `the environment variable '${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. ` +
     'The 51Degrees cloud service is accessed using a \'ResourceKey\'. ' +
     'For more information ' +
-    'see https://51degrees.com/documentation/_info__resource_keys.html. ' +
+    'see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=resource-key-required. ' +
     'Native model lookup is not available as a free service. This means that ' +
     'you will first need a license key, which can be purchased from our ' +
-    'pricing page: https://51degrees.com/pricing. Once this is done, a resource ' +
+    'pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=resource-key-required. Once this is done, a resource ' +
     'key with the properties required by this example can be created at ' +
-    'https://configure.51degrees.com/QKyYH5XT. You can now populate the ' +
+    'https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-nativemodellookup-console-nativemodellookup.js&utm_term=resource-key-required. You can now populate the ' +
     'environment variable mentioned at the start of this message with the ' +
     'resource key or pass it as the first argument on the command line.');
   }

--- a/fiftyone.devicedetection.cloud/examples/cloud/taclookup-console/tacLookup.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/taclookup-console/tacLookup.js
@@ -94,12 +94,12 @@ const run = async function (options, output) {
       `'${ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud ` +
       'service is accessed using a \'ResourceKey\'. For more information ' +
       'see ' +
-      'https://51degrees.com/documentation/_info__resource_keys.html. ' +
+      'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=resource-key-required. ' +
       'TAC lookup is not available as a free service. This means that ' +
       'you will first need a license key, which can be purchased from our ' +
-      'pricing page: https://51degrees.com/pricing. Once this is done, a resource ' +
+      'pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=resource-key-required. Once this is done, a resource ' +
       'key with the properties required by this example can be created at ' +
-      'https://configure.51degrees.com/QKyYH5XT. You can now populate the ' +
+      'https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=resource-key-required. You can now populate the ' +
       'environment variable mentioned at the start of this message with the ' +
       'resource key or pass it as the first argument on the command line.'
     );
@@ -117,7 +117,7 @@ const run = async function (options, output) {
   // For a demonstration of how to do this in code instead, see the
   // NativeModelLookup example.
   // For more information about builders in general see the documentation at
-  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-taclookup-console-taclookup.js&utm_term=run
   const pipeline = new PipelineBuilder().buildFromConfiguration(options);
 
   // To monitor the pipeline we can put in listeners for various log events.

--- a/fiftyone.devicedetection.cloud/examples/cloud/useragentclienthints-web/userAgentClientHintsWeb.js
+++ b/fiftyone.devicedetection.cloud/examples/cloud/useragentclienthints-web/userAgentClientHintsWeb.js
@@ -79,7 +79,7 @@ let server;
 let pipeline;
 const setPipeline = (resourceKey) => {
   // Create a new Device Detection pipeline and set the config.
-  // You need to create a resource key at https://configure.51degrees.com
+  // You need to create a resource key at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-useragentclienthints-web-useragentclienthintsweb.js&utm_term=setpipeline
   // and paste it into the code.
   pipeline = new DeviceDetectionCloudPipelineBuilder({
     resourceKey
@@ -93,7 +93,7 @@ const setPipeline = (resourceKey) => {
 if (myResourceKey === '!!YOUR_RESOURCE_KEY!!' &&
   process.env.JEST_WORKER_ID === undefined) {
   console.log('You need to create a resource key at ' +
-        'https://configure.51degrees.com and paste it into the code, ' +
+        'https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-useragentclienthints-web-useragentclienthintsweb.js&utm_term=resource-key-required and paste it into the code, ' +
         'replacing !!YOUR_RESOURCE_KEY!!');
 } else {
   const http = require('http');
@@ -112,7 +112,7 @@ if (myResourceKey === '!!YOUR_RESOURCE_KEY!!' &&
       // requested. So set whatever headers are required by the browser in
       // order to return the evidence needed by the pipeline.
       // More info on this can be found at
-      // https://51degrees.com/blog/user-agent-client-hints
+      // https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-examples-cloud-useragentclienthints-web-useragentclienthintsweb.js&utm_term=server
       core.Helpers.setResponseHeaders(res, flowData);
 
       res.setHeader('Content-Type', 'text/html');

--- a/fiftyone.devicedetection.cloud/readme.md
+++ b/fiftyone.devicedetection.cloud/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **Node Device Detection Cloud**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-readme.md&utm_term=top "Data rewards the curious") **Node Device Detection Cloud**
 
-[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 This project contains 51Degrees Device Detection engines that can be used with the [Pipeline API](https://github.com/51Degrees/pipeline-node).
@@ -50,7 +50,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
+Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.cloud-readme.md&utm_term=tests) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
 
 There are other environment variables that you will also need to set in your test environment before running all tests:
 - `TEST_SUPER_RESOURCE_KEY`: This key contains all `SetHeader*` properties.

--- a/fiftyone.devicedetection.onpremise/deviceDetectionOnPremise.js
+++ b/fiftyone.devicedetection.onpremise/deviceDetectionOnPremise.js
@@ -197,7 +197,7 @@ class DeviceDetectionOnPremise extends Engine {
    * will be restricted to
    * @param {string} options.licenceKeys license key(s) used by the
    * data file update service. A key can be obtained from the
-   * 51Degrees website: https://51degrees.com/pricing.
+   * 51Degrees website: https://51degrees.com/pricing?utm_source=code&utm_medium=comment&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-devicedetectiononpremise.js&utm_term=constructor.
    * If you do not wish to use a key then you can specify
    * an empty string, but this will cause automatic updates to
    * be disabled.

--- a/fiftyone.devicedetection.onpremise/deviceDetectionOnPremisePipelineBuilder.js
+++ b/fiftyone.devicedetection.onpremise/deviceDetectionOnPremisePipelineBuilder.js
@@ -42,7 +42,7 @@ class DeviceDetectionOnPremisePipelineBuilder extends PipelineBuilder {
    * @param {object} options the options for the pipeline builder
    * @param {string} [options.licenceKeys] license key(s) used by the
    * data file update service. A key can be obtained from the
-   * 51Degrees website: https://51degrees.com/pricing.
+   * 51Degrees website: https://51degrees.com/pricing?utm_source=code&utm_medium=comment&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-devicedetectiononpremisepipelinebuilder.js&utm_term=constructor.
    * This parameter MUST be set when using a data file.
    * If you do not wish to use a key then you can specify
    * an empty string, but this will cause automatic updates

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/dataFileSystemWatcher.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/dataFileSystemWatcher.js
@@ -48,7 +48,7 @@ const ExampleUtils = require(path.join(__dirname, '/../exampleUtils')).ExampleUt
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-datafilesystemwatcher.js&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
@@ -58,13 +58,13 @@ const args = process.argv.slice(2);
 const datafile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
 
 // Set your license key, if you don't have a license key already you can
-// obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing
+// obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-datafilesystemwatcher.js&utm_term=top
 
 const myLicenseKey = process.env.LICENSE_KEY || '!!YOUR_LICENSE_KEY!!';
 
 if (myLicenseKey === '!!YOUR_LICENSE_KEY!!') {
   console.log("You need a license key to run this example, if you don't have one already " +
-  'you can obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing');
+  'you can obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-datafilesystemwatcher.js&utm_term=license-key-required');
 } else {
   // Check if datafile exists
 
@@ -84,7 +84,7 @@ if (myLicenseKey === '!!YOUR_LICENSE_KEY!!') {
     // Path to your data file
     dataFile: datafile,
     // For automatic updates to work you will need to provide a license key.
-    // A license key can be obtained with a subscription from https://51degrees.com/pricing
+    // A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-datafilesystemwatcher.js&utm_term=licencekeys
     licenceKeys: myLicenseKey,
     // Enable automatic updates.
     autoUpdate: true,

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updateOnStartUp.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updateOnStartUp.js
@@ -48,7 +48,7 @@ const ExampleUtils = require(path.join(__dirname, '/../exampleUtils')).ExampleUt
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updateonstartup.js&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
@@ -58,13 +58,13 @@ const args = process.argv.slice(2);
 const datafile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
 
 // Set your license key, if you don't have a license key already you can
-// obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing
+// obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updateonstartup.js&utm_term=top
 
 const myLicenseKey = process.env.LICENSE_KEY || '!!YOUR_LICENSE_KEY!!';
 
 if (myLicenseKey === '!!YOUR_LICENSE_KEY!!') {
   console.log("You need a license key to run this example, if you don't have one already " +
-  'you can obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing');
+  'you can obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updateonstartup.js&utm_term=license-key-required');
 } else {
 // Check if datafile exists
 
@@ -87,7 +87,7 @@ if (myLicenseKey === '!!YOUR_LICENSE_KEY!!') {
     // Path to your data file
     dataFile: datafile,
     // For automatic updates to work you will need to provide a license key.
-    // A license key can be obtained with a subscription from https://51degrees.com/pricing
+    // A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updateonstartup.js&utm_term=licencekeys
     licenceKeys: myLicenseKey,
     // Enable automatic updates.
     autoUpdate: true,

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updatePollingInterval.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/automaticupdates/updatePollingInterval.js
@@ -48,7 +48,7 @@ const ExampleUtils = require(path.join(__dirname, '/../exampleUtils')).ExampleUt
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updatepollinginterval.js&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Load in a datafile
@@ -58,13 +58,13 @@ const args = process.argv.slice(2);
 const datafile = args.length > 0 ? args[0] : ExampleUtils.findFile(LITE_V_4_1_HASH);
 
 // Set your license key, if you don't have a license key already you can
-// obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing
+// obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updatepollinginterval.js&utm_term=top
 
 const myLicenseKey = process.env.LICENSE_KEY || '!!YOUR_LICENSE_KEY!!';
 
 if (myLicenseKey === '!!YOUR_LICENSE_KEY!!') {
   console.log("You need a license key to run this example, if you don't have one already " +
-  'you can obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing');
+  'you can obtain one by subscribing to a 51Degrees bundle: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updatepollinginterval.js&utm_term=license-key-required');
 } else {
   // Check if datafile exists
 
@@ -85,7 +85,7 @@ if (myLicenseKey === '!!YOUR_LICENSE_KEY!!') {
     // Path to your data file
     dataFile: datafile,
     // For automatic updates to work you will need to provide a license key.
-    // A license key can be obtained with a subscription from https://51degrees.com/pricing
+    // A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-automaticupdates-updatepollinginterval.js&utm_term=licencekeys
     licenceKeys: myLicenseKey,
     // Enable automatic updates.
     autoUpdate: true,

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/exampleUtils.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/exampleUtils.js
@@ -114,14 +114,14 @@ class ExampleUtils {
         'https://github.com/51Degrees/device-detection-data. ' +
         'Find out about the Enterprise data file, which ' +
         'includes automatic daily updates, on our pricing ' +
-        'page: https://51degrees.com/pricing');
+        'page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-exampleutils.js&utm_term=data-file-age-warning');
     }
     if (dataTier === 'Lite') {
       console.warn('This example is using the \'Lite\' ' +
         'data file. This is used for illustration, and ' +
         'has limited accuracy and capabilities. Find ' +
         'out about the Enterprise data file on our ' +
-        'pricing page: https://51degrees.com/pricing');
+        'pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-exampleutils.js&utm_term=lite-data-file');
     }
   }
 

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.js
@@ -55,7 +55,7 @@ const exampleConstants = require51('fiftyone.devicedetection.shared').exampleCon
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.js&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 const outputValue = function (name, value) {
@@ -103,7 +103,7 @@ const analyse = async function (evidence, pipeline, output) {
 
   // Display the results of the detection, which are called
   // device properties. See the property dictionary at
-  // https://51degrees.com/developers/property-dictionary
+  // https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.js&utm_term=analyse
   // for details of all available properties.
   message += outputValue('Mobile Device', DataExtension.getValueHelper(device, 'ismobile'));
   message += outputValue('Platform Name', DataExtension.getValueHelper(device, 'platformname'));
@@ -118,15 +118,15 @@ const run = async function (dataFile, output) {
   // In this example, we use the DeviceDetectionOnPremisePipelineBuilder
   // and configure it in code. For more information about
   // pipelines in general see the documentation at
-  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.js&utm_term=pipeline
   const pipeline = new DeviceDetectionOnPremisePipelineBuilder({
     dataFile,
     // We use the low memory profile as its performance is
     // sufficient for this example. See the documentation for
     // more detail on this and other configuration options:
-    // https://51degrees.com/documentation/_device_detection__features__performance_options.html
-    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
-    // https://51degrees.com/documentation/_features__usage_sharing.html
+    // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.js&utm_term=performanceprofile
+    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.js&utm_term=performanceprofile
+    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.js&utm_term=performanceprofile
     performanceProfile: 'LowMemory',
     // inhibit sharing usage for this test, usually this
     // should be set 'true'

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.ts
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-console/gettingStarted.ts
@@ -52,7 +52,7 @@ const ExampleUtils: {
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.ts&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 const outputValue = function (name: any, value: any) {
@@ -101,7 +101,7 @@ const analyse = async function (evidence: Map<string, string>, pipeline: Pipelin
 
   // Display the results of the detection, which are called
   // device properties. See the property dictionary at
-  // https://51degrees.com/developers/property-dictionary
+  // https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.ts&utm_term=analyse
   // for details of all available properties.
   message += outputValue('Mobile Device', dataExtension.getValueHelper(device, 'ismobile'));
   message += outputValue('Platform Name', dataExtension.getValueHelper(device, 'platformname'));
@@ -116,15 +116,15 @@ const run = async function (dataFile: string) {
   // In this example, we use the DeviceDetectionOnPremisePipelineBuilder
   // and configure it in code. For more information about
   // pipelines in general see the documentation at
-  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.ts&utm_term=pipeline
   const pipeline = new DeviceDetectionOnPremisePipelineBuilder({
     dataFile,
     // We use the low memory profile as its performance is
     // sufficient for this example. See the documentation for
     // more detail on this and other configuration options:
-    // https://51degrees.com/documentation/_device_detection__features__performance_options.html
-    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
-    // https://51degrees.com/documentation/_features__usage_sharing.html
+    // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.ts&utm_term=performanceprofile
+    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.ts&utm_term=performanceprofile
+    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-console-gettingstarted.ts&utm_term=performanceprofile
     performanceProfile: 'LowMemory',
     // inhibit sharing usage for this test, usually this
     // should be set 'true'

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-web/gettingStarted.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-web/gettingStarted.js
@@ -162,7 +162,7 @@ const server = http.createServer((req, res) => {
       // requested. So set whatever headers are required by the browser in
       // order to return the evidence needed by the pipeline.
       // More info on this can be found at
-      // https://51degrees.com/blog/user-agent-client-hints
+      // https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-web-gettingstarted.js&utm_term=server
       core.Helpers.setResponseHeaders(res, flowData);
 
       // Obtain all used evidence

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-web/index.pug
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/gettingstarted-web/index.pug
@@ -76,7 +76,7 @@ html
         | #[a(href='https://github.com/51Degrees/device-detection-data') device-detection-data]
         | repository on Github. Find out about the
         | Enterprise data file, which includes automatic daily updates, on our 
-        | #[a(href='https://51degrees.com/pricing') pricing page].
+        | #[a(href='https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-web-index.pug&utm_term=client-hints') pricing page].
     
     div(id='content')
       div(id='response-headers')
@@ -191,7 +191,7 @@ html
           | WARNING: You are using the free 'Lite' data file. This does not include 
           | the client-side evidence capabilities of the paid-for data file, so you 
           | will not see any additional data below. Find out about the Enterprise 
-          | data file on our #[a(href='https://51degrees.com/pricing') pricing page].
+          | data file on our #[a(href='https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-gettingstarted-web-index.pug&utm_term=client-side-evidence-and-apple-models') pricing page].
 
 script !{fiftyOneJs}
 

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/matchmetrics-console/matchMetrics.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/matchmetrics-console/matchMetrics.js
@@ -64,7 +64,7 @@ const exampleConstants = require51('fiftyone.devicedetection.shared').exampleCon
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-matchmetrics-console-matchmetrics.js&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 // Here we make a function that gets a userAgent as evidence and
@@ -183,7 +183,7 @@ const run = async function (dataFile, output, evidenceList) {
   // In this example, we use the DeviceDetectionOnPremisePipelineBuilder
   // and configure it in code. For more information about
   // pipelines in general see the documentation at
-  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-matchmetrics-console-matchmetrics.js&utm_term=pipeline
   const pipeline = new DeviceDetectionOnPremisePipelineBuilder({
     dataFile,
     // Prefer low memory profile where all data streamed from disk on-demand.
@@ -201,7 +201,7 @@ const run = async function (dataFile, output, evidenceList) {
     // in the output.
     //
     // If using the full on-premise data file the hardwarename property will be present in the
-    // data file. See https://51degrees.com/pricing
+    // data file. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-matchmetrics-console-matchmetrics.js&utm_term=restrictedproperties
     //
     // The 'ismobile' and 'hardwarename' properties are both part of the 'hardware' component.
     // The remaining properties are from match metrics.

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/metadata-console/metaData.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/metadata-console/metaData.js
@@ -73,7 +73,7 @@ const ExampleUtils = require(path.join(__dirname, '/../exampleUtils')).ExampleUt
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-metadata-console-metadata.js&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 
 const truncateToNl = function (string) {
@@ -170,15 +170,15 @@ const run = async function (dataFile, output) {
   // In this example, we use the DeviceDetectionOnPremisePipelineBuilder
   // and configure it in code. For more information about
   // pipelines in general see the documentation at
-  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-metadata-console-metadata.js&utm_term=pipeline
   const pipeline = new DeviceDetectionOnPremisePipelineBuilder({
     dataFile,
     // We use the low memory profile as its performance is
     // sufficient for this example. See the documentation for
     // more detail on this and other configuration options:
-    // https://51degrees.com/documentation/_device_detection__features__performance_options.html
-    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
-    // https://51degrees.com/documentation/_features__usage_sharing.html
+    // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-metadata-console-metadata.js&utm_term=performanceprofile
+    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-metadata-console-metadata.js&utm_term=performanceprofile
+    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-metadata-console-metadata.js&utm_term=performanceprofile
     performanceProfile: 'LowMemory',
     // inhibit sharing usage for this test, usually this
     // should be set 'true'

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/offlineprocessing-console/offlineProcessing.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/offlineprocessing-console/offlineProcessing.js
@@ -74,7 +74,7 @@ const DataExtension = require51('fiftyone.devicedetection.shared').dataExtension
 //
 // Note that the Lite data file is only used for illustration, and has limited accuracy
 // and capabilities. Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-offlineprocessing-console-offlineprocessing.js&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 // This file contains the 20,000 most commonly seen combinations of header values
 // that are relevant to device detection. For example, User-Agent and UA-CH headers.
@@ -136,15 +136,15 @@ const run = async function (dataFile, evidenceFile, outputFile, outputFunc) {
   // In this example, we use the DeviceDetectionOnPremisePipelineBuilder
   // and configure it in code. For more information about
   // pipelines in general see the documentation at
-  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+  // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-offlineprocessing-console-offlineprocessing.js&utm_term=pipeline
   const pipeline = new DeviceDetectionOnPremisePipelineBuilder({
     dataFile,
     // We use the low memory profile as its performance is
     // sufficient for this example. See the documentation for
     // more detail on this and other configuration options:
-    // https://51degrees.com/documentation/_device_detection__features__performance_options.html
-    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
-    // https://51degrees.com/documentation/_features__usage_sharing.html
+    // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-offlineprocessing-console-offlineprocessing.js&utm_term=performanceprofile
+    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-offlineprocessing-console-offlineprocessing.js&utm_term=performanceprofile
+    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-offlineprocessing-console-offlineprocessing.js&utm_term=performanceprofile
     performanceProfile: 'LowMemory',
     //  Inhibit sharing usage for this example.
     // In general, off line processing usage should NOT be shared back to 51Degrees.
@@ -154,7 +154,7 @@ const run = async function (dataFile, evidenceFile, outputFile, outputFunc) {
     // in order to help us improve detection of new devices/browsers/etc, then
     // this additional data will need to be collected and included as evidence
     // to the Pipeline. See
-    // https://51degrees.com/documentation/_features__usage_sharing.html#Low_Level_Usage_Sharing
+    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-offlineprocessing-console-offlineprocessing.js&utm_term=shareusage#Low_Level_Usage_Sharing
     // for more details on this.
     shareUsage: false,
     // inhibit auto-update of the data file for this test

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/performance-console/performance.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/performance-console/performance.js
@@ -82,7 +82,7 @@ parser.add_argument('-jo', '--jsonoutput', { help: 'JSON output file name' });
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-performance-console-performance.js&utm_term=lite_v_4_1_hash
 const LITE_V_4_1_HASH = '51Degrees-LiteV4.1.hash';
 const UA_CSV = '20000 User Agents.csv';
 

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/updatedatafile-console/updatedatafile.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/updatedatafile-console/updatedatafile.js
@@ -53,10 +53,10 @@ const KeyUtils = require51('fiftyone.devicedetection.shared').keyUtils;
  *
  * ## License Key
  * In order to test this example you will need a 51Degrees Enterprise license which can be
- * purchased from our [pricing page](//51degrees.com/pricing/annual). Look for our "Bigger" or
+ * purchased from our [pricing page](https://51degrees.com/pricing/annual?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-updatedatafile-console-updatedatafile.js&utm_term=header). Look for our "Bigger" or
  * "Biggest" options.
  * # Data Files
- * You can find out more about data files, licenses etc. at our (FAQ page)[//51degrees.com/resources/faqs]
+ * You can find out more about data files, licenses etc. at our (FAQ page)[https://51degrees.com/resources/faqs?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-updatedatafile-console-updatedatafile.js&utm_term=header]
  * ## Enterprise Data File
  * Enterprise (fully-featured) data files are typically released by 51Degrees four days a week
  * (Mon-Thu) and on-premise deployments can fetch and download those files automatically. Equally,
@@ -182,7 +182,7 @@ const run = async function (dataFilePath, licenseKey, interactive, output) {
   if (!licenseKey || KeyUtils.isInvalidKey(licenseKey)) {
     console.error('In order to test this example you will need a 51Degrees Enterprise ' +
       'license which can be obtained on a trial basis or purchased from our\n' +
-      'pricing page http://51degrees.com/pricing. You must supply the license ' +
+      'pricing page https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-updatedatafile-console-updatedatafile.js&utm_term=enterprise-license-required. You must supply the license ' +
       'key as an argument to this program, or as an environment or system variable ' +
       `named '${UPDATE_EXAMPLE_LICENSE_KEY_NAME}'`);
     throw new Error('No license key available');
@@ -315,7 +315,7 @@ const run = async function (dataFilePath, licenseKey, interactive, output) {
     // Enable automatic updates once the pipeline has started
     autoUpdate: true,
     // For automatic updates to work you will need to provide a license key.
-    // A license key can be obtained with a subscription from https://51degrees.com/pricing
+    // A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-updatedatafile-console-updatedatafile.js&utm_term=licencekeys
     licenceKeys: licenseKey,
     // Enable update on startup, the auto update system
     // will be used to check for an update before the

--- a/fiftyone.devicedetection.onpremise/examples/onpremise/useragentclienthints-web/userAgentClientHintsWeb.js
+++ b/fiftyone.devicedetection.onpremise/examples/onpremise/useragentclienthints-web/userAgentClientHintsWeb.js
@@ -111,7 +111,7 @@ const server = http.createServer((req, res) => {
     // requested. So set whatever headers are required by the browser in
     // order to return the evidence needed by the pipeline.
     // More info on this can be found at
-    // https://51degrees.com/blog/user-agent-client-hints
+    // https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-examples-onpremise-useragentclienthints-web-useragentclienthintsweb.js&utm_term=server
     core.Helpers.setResponseHeaders(res, flowData);
 
     res.setHeader('Content-Type', 'text/html');

--- a/fiftyone.devicedetection.onpremise/readme.md
+++ b/fiftyone.devicedetection.onpremise/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **Node Device Detection On-Premise**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-readme.md&utm_term=top "Data rewards the curious") **Node Device Detection On-Premise**
 
-[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 This project contains 51Degrees Device Detection engines that can be used with the [Pipeline API](https://github.com/51Degrees/pipeline-node).
@@ -26,9 +26,9 @@ npm install fiftyone.devicedetection.onpremise
 ### On-Premise
 When running on-premise, a local Hash V4.1 data file is required.
 
-[**Hash**](https://51degrees.com/documentation/_device_detection__hash.html): A large binary file populated with User-Agent signatures allowing very fast detection speeds.
+[**Hash**](https://51degrees.com/documentation/_device_detection__hash.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-readme.md&utm_term=on-premise): A large binary file populated with User-Agent signatures allowing very fast detection speeds.
 
-51Degrees provides [multiple options](https://51degrees.com/Licencing-Pricing/On-Premise), some of which support automatic updates through the Pipeline API.
+51Degrees provides [multiple options](https://51degrees.com/Licencing-Pricing/On-Premise?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-readme.md&utm_term=on-premise), some of which support automatic updates through the Pipeline API.
 
 If the module is installed directly from Git then the binaries are also required. These binaries are native module which contains the core engine of device detection. Below are the steps to build these binaries:
 #### Pre-requisites
@@ -71,7 +71,7 @@ If the module is installed directly from Git then the binaries are also required
   - MacOS:
     - FiftyOneDeviceDetectionHashV4-darwin-[ Node version ].node
       - e.g. FiftyOneDeviceDetectionHashV4-darwin-10.node for Node 10.
-  - Please see the [tested versions page](https://51degrees.com/documentation/_info__tested_versions.html) for Node versions that we currently test against. The software may run fine against other versions, but extra caution should be applied.
+  - Please see the [tested versions page](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.onpremise-readme.md&utm_term=build-steps) for Node versions that we currently test against. The software may run fine against other versions, but extra caution should be applied.
   - You can optionally clear up by removing all the build files and folders except for the *.node file that's been created.
   - `WARNING`: `npm install` removes this copied file, so you will need to do the above steps again after running `npm install`
 

--- a/fiftyone.devicedetection.shared/errorMessages.js
+++ b/fiftyone.devicedetection.shared/errorMessages.js
@@ -37,11 +37,11 @@ module.exports = {
     'included with this distribution. Try changing to a platform and Node ' +
     'version from the list of available modules: %s. If the platform/version ' +
     'you want is not listed then please contact us directly for assistance: ' +
-    'https://51degrees.com/contact-us. Original error: \'%s\'',
+    'https://51degrees.com/contact-us?utm_source=code&utm_medium=comment&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.shared-errormessages.js&utm_term=nativemodulenotfound. Original error: \'%s\'',
   invalidFileExtension: 'dataFilePath must point to a file with a ".hash" ' +
     'extension',
   licenseKeyRequired: 'license key is required. A key can be obtained from ' +
-    'the 51Degrees website: https://51degrees.com/pricing. If you do not ' +
+    'the 51Degrees website: https://51degrees.com/pricing?utm_source=code&utm_medium=comment&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.shared-errormessages.js&utm_term=licensekeyrequired. If you do not ' +
     'wish to use a key then you can specify an empty string, but this will ' +
     'cause automatic updates to be disabled.',
   invalidPerformanceProfile: 'The performance profile \'%s\' is not valid',

--- a/fiftyone.devicedetection.shared/examples/exampleConstants.js
+++ b/fiftyone.devicedetection.shared/examples/exampleConstants.js
@@ -58,7 +58,7 @@ module.exports = {
 
     // Links:
     // - [getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
-    // - [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints)
+    // - [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.shared-examples-exampleconstants.js&utm_term=defaultevidencevalues)
     // - [OpenRTB 2.6 spec](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectuseragent)
 
     // 51Degrees historically used HTTP header map to represent User-Agent Client Hints and expected the evidence to

--- a/fiftyone.devicedetection.shared/readme.md
+++ b/fiftyone.devicedetection.shared/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **Node Device Detection Shared**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.shared-readme.md&utm_term=top "Data rewards the curious") **Node Device Detection Shared**
 
-[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection.shared-readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 This project contains 51Degrees Device Detection engines that can be used with the [Pipeline API](https://github.com/51Degrees/pipeline-node).

--- a/fiftyone.devicedetection/deviceDetectionPipelineBuilder.js
+++ b/fiftyone.devicedetection/deviceDetectionPipelineBuilder.js
@@ -40,7 +40,7 @@ class DeviceDetectionPipelineBuilder extends PipelineBuilder {
    * @param {object} options the options for the pipeline builder
    * @param {string} options.licenceKeys license key(s) used by the
    * data file update service. A key can be obtained from the
-   * 51Degrees website: https://51degrees.com/pricing.
+   * 51Degrees website: https://51degrees.com/pricing?utm_source=code&utm_medium=comment&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-devicedetectionpipelinebuilder.js&utm_term=constructor.
    * This parameter MUST be set when using a data file.
    * If you do not wish to use a key then you can specify
    * an empty string, but this will cause automatic updates

--- a/fiftyone.devicedetection/examples/gettingStarted.js
+++ b/fiftyone.devicedetection/examples/gettingStarted.js
@@ -52,14 +52,14 @@ const DeviceDetectionPipelineBuilder = require51('fiftyone.devicedetection').Dev
 
 // Create the device detection pipeline with the desired settings.
 
-// You need to create a resource key at https://configure.51degrees.com
+// You need to create a resource key at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-examples-gettingstarted.js&utm_term=top
 // and paste it into the code, replacing !!YOUR_RESOURCE_KEY!! below.
 
 const myResourceKey = process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
 
 if (myResourceKey === '!!YOUR_RESOURCE_KEY!!') {
   console.log('You need to create a resource key at ' +
-        'https://configure.51degrees.com and paste it into the code, ' +
+        'https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-examples-gettingstarted.js&utm_term=resource-key-required and paste it into the code, ' +
         'replacing !!YOUR_RESOURCE_KEY!!');
   console.log('Make sure to include the ismobile property ' +
         'as it is used by this example.');

--- a/fiftyone.devicedetection/readme.md
+++ b/fiftyone.devicedetection/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **Node Device Detection**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-readme.md&utm_term=top "Data rewards the curious") **Node Device Detection**
 
-[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 This project contains 51Degrees Device Detection engines that can be used with the [Pipeline API](https://github.com/51Degrees/pipeline-node).
@@ -45,7 +45,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-You need to obtain a 51Degrees cloud resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
+You need to obtain a 51Degrees cloud resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=fiftyone.devicedetection-readme.md&utm_term=tests) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
 
 To run the tests, navigate to the module directory and execute:
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **Node Device Detection**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=top "Data rewards the curious") **Node Device Detection**
 
-[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 This project contains 51Degrees Device Detection engines that can be used with the [Pipeline API](https://github.com/51Degrees/pipeline-node).
@@ -23,8 +23,8 @@ Both options use the same evidence values and expose (almost all) the same prope
 
 ### Dependencies
 
-For runtime dependencies, see our [dependencies](https://51degrees.com/documentation/_info__dependencies.html) page.
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+For runtime dependencies, see our [dependencies](https://51degrees.com/documentation/_info__dependencies.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=dependencies) page.
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=dependencies) page shows 
 the Node versions that we currently test against. The software may run fine against other 
 versions, but additional caution should be applied.
 
@@ -34,17 +34,17 @@ The API can either use our cloud service to get its data or it can use a local (
 
 #### Cloud
 
-You will require a [resource key](https://51degrees.com/documentation/_info__resource_keys.html)
+You will require a [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud)
 to use the Cloud API. You can create resource keys using our 
-[configurator](https://configure.51degrees.com/), see our 
-[documentation](https://51degrees.com/documentation/_concepts__configurator.html) on how to use this.
+[configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud), see our 
+[documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=cloud) on how to use this.
 
 #### On-Premise
 
 In order to perform device detection on-premise, you will need to use a 51Degrees data file. 
 This repository includes a free, 'lite' file in the 'device-detection-data' sub-module that has a 
 significantly reduced set of properties. To obtain a file with a more complete set of device 
-properties see the [51Degrees website](https://51degrees.com/pricing). If you want to use the lite 
+properties see the [51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=on-premise). If you want to use the lite 
 file, you will need to install [GitLFS](https://git-lfs.github.com/):
 
 ```
@@ -117,7 +117,7 @@ section explains how to do this.
   - MacOS:
     - FiftyOneDeviceDetectionHashV4-darwin-[ Node version ].node
       - e.g. FiftyOneDeviceDetectionHashV4-darwin-10.node for Node 10.
-  - Please see the [tested versions page](https://51degrees.com/documentation/_info__tested_versions.html) for Node versions that we currently test against. The software may run fine against other versions, but extra caution should be applied.
+  - Please see the [tested versions page](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=build-steps) for Node versions that we currently test against. The software may run fine against other versions, but extra caution should be applied.
   - You can optionally clear up by removing all the build files and folders except for the *.node file that's been created.
   - `WARNING`: `npm install` removes this copied file, so you will need to do the above steps again after running `npm install`
 
@@ -172,7 +172,7 @@ npm install jest --global
 
 You will also need to install any required packages for the examples in the **Examples** section.
 
-Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
+Add a 51Degrees cloud resource key in the fiftyone.devicedetection/package.json file for cloud tests. You can obtain a resource key from the [51Degrees Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-node&utm_content=readme.md&utm_term=tests) and assign it to the environment variable `RESOURCE_KEY` in your test environment.
 
 There are other environment variables that you will also need to set in your test environment before running all tests:
 - `TEST_SUPER_RESOURCE_KEY`: This key contains all `SetHeader*` properties.

--- a/run_examples.md
+++ b/run_examples.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **Node Device Detection**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=docs&utm_campaign=device-detection-node&utm_content=run_examples.md&utm_term=top "Data rewards the curious") **Node Device Detection**
 
-[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-node/index.html?utm_source=github&utm_medium=docs&utm_campaign=device-detection-node&utm_content=run_examples.md&utm_term=top "developer documentation")
 
 # Running examples
 


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

109 links across 36 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).