### PR TITLE
FIX: Assert at least one matched User-Agent, not exactly one

### DIFF
--- a/fiftyone.devicedetection.onpremise/tests/deviceDetectionOnPremiseValue.test.js
+++ b/fiftyone.devicedetection.onpremise/tests/deviceDetectionOnPremiseValue.test.js
@@ -215,7 +215,12 @@ describe('deviceDetectionOnPremise', () => {
     expect(userAgents.value).not.toBeNull();
     expect(userAgents.value).toBeDefined();
 
-    expect(userAgents.value.length).toBe(1);
+    // Since the detection result shape was unified in device-detection-cxx
+    // (issue #362), a single User-Agent produces one result - and so one
+    // matched User-Agent - per component the engine populates, rather than
+    // exactly one overall. The number depends on the data file, so assert that
+    // at least one is returned and validate each of them below.
+    expect(userAgents.value.length).toBeGreaterThanOrEqual(1);
 
     userAgents.value.forEach(matchedUa => {
       matchedUa.split(/[_{}]/g).forEach(substring => {


### PR DESCRIPTION
Relates to #TASK

Updates the on-premise value test for the unified detection result shape
introduced in 51Degrees/device-detection-cxx#362 (merged in
51Degrees/device-detection-cxx#385).

`deviceDetectionOnPremiseValue.test.js` asserted that a single User-Agent
produces exactly one matched User-Agent. #362 removed the fast path that
coupled result shape to evidence cardinality, so detection now produces one
result - and so one matched User-Agent - per component the engine populates.
A single User-Agent yields several rather than one.

## Why this is urgent

The submodule bump landed on `main` in #426, so `main` already builds against
the new native library while still asserting `toBe(1)`. The check has not run
against it yet - #426's PR run was the UTM link lint only, and the nightly that
morning ran before the merge - so the next nightly is the first that would go
red.

## Change

`expect(userAgents.value.length).toBe(1)` becomes a lower bound of 1. The
number depends on which components the data file makes available, so pinning a
literal would be brittle across data file revisions. The per-entry check that
every matched substring occurs at the expected offset in the original
User-Agent is unchanged; that is the substantive assertion.

The new assertion holds under both the old shape (1) and the new one, so it is
safe to land independently of any further submodule movement.

## Verification

Test-only change; syntax checked with `node --check`. Not executed locally -
this package needs a native addon build that was not available in the
environment used. CI is the check.

## Related

The same assertion is being corrected in device-detection-java,
device-detection-dotnet, device-detection-python and device-detection-go.
device-detection-php is unaffected - it asserts no result counts.
